### PR TITLE
Improve IDE support for symfony legacy code

### DIFF
--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -33,7 +33,7 @@ abstract class sfAction extends sfComponent
    * @param string    $moduleName The module name.
    * @param string    $actionName The action name.
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    */
   public function initialize($context, $moduleName, $actionName)
   {

--- a/lib/action/sfAction.class.php
+++ b/lib/action/sfAction.class.php
@@ -17,6 +17,9 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author     Sean Kerr <sean@code-box.org>
  * @version    SVN: $Id$
+ *
+ * @method sfWebController getController()
+ * @method sfWebResponse getResponse()
  */
 abstract class sfAction extends sfComponent
 {
@@ -186,7 +189,7 @@ abstract class sfAction extends sfComponent
    * This method stops the action. So, no code is executed after a call to this method.
    *
    * @param  string $url         Url
-   * @param  string $statusCode  Status code (default to 302)
+   * @param  int    $statusCode  Status code (default to 302)
    *
    * @throws sfStopException
    */
@@ -211,7 +214,7 @@ abstract class sfAction extends sfComponent
    *
    * @param  bool   $condition  A condition that evaluates to true or false
    * @param  string $url        Url
-   * @param  string $statusCode Status code (default to 302)
+   * @param  int    $statusCode Status code (default to 302)
    *
    * @throws sfStopException
    *
@@ -234,7 +237,7 @@ abstract class sfAction extends sfComponent
    *
    * @param  bool   $condition  A condition that evaluates to true or false
    * @param  string $url        Url
-   * @param  string $statusCode Status code (default to 302)
+   * @param  int    $statusCode Status code (default to 302)
    *
    * @throws sfStopException
    *
@@ -259,7 +262,7 @@ abstract class sfAction extends sfComponent
    *
    * @param string $text Text to append to the response
    *
-   * @return sfView::NONE
+   * @return string sfView::NONE
    */
   public function renderText($text)
   {
@@ -275,7 +278,7 @@ abstract class sfAction extends sfComponent
    *
    * @param mixed $data Data to encode as JSON
    *
-   * @return sfView::NONE
+   * @return string sfView::NONE
    */
   public function renderJson($data)
   {
@@ -318,7 +321,7 @@ abstract class sfAction extends sfComponent
    * @param  string $templateName partial name
    * @param  array  $vars         vars
    *
-   * @return sfView::NONE
+   * @return string sfView::NONE
    *
    * @see    getPartial
    */
@@ -362,7 +365,7 @@ abstract class sfAction extends sfComponent
    * @param  string  $componentName  component name
    * @param  array   $vars          vars
    *
-   * @return sfView::NONE
+   * @return string  sfView::NONE
    *
    * @see    getComponent
    */

--- a/lib/action/sfActionStack.class.php
+++ b/lib/action/sfActionStack.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,6 +21,7 @@
  */
 class sfActionStack
 {
+  /** @var sfActionStackEntry[] */
   protected
     $stack = array();
 

--- a/lib/action/sfComponent.class.php
+++ b/lib/action/sfComponent.class.php
@@ -56,7 +56,7 @@ abstract class sfComponent
    * @param string    $moduleName The module name.
    * @param string    $actionName The action name.
    *
-   * @return boolean true, if initialization completes successfully, otherwise false
+   * @return void
    */
   public function initialize($context, $moduleName, $actionName)
   {

--- a/lib/action/sfComponent.class.php
+++ b/lib/action/sfComponent.class.php
@@ -18,20 +18,31 @@
  */
 abstract class sfComponent
 {
-  protected
-    $moduleName             = '',
-    $actionName             = '',
-    $context                = null,
-    $dispatcher             = null,
-    $request                = null,
-    $response               = null,
-    $varHolder              = null,
-    $requestParameterHolder = null;
+  /** @var string */
+  protected $moduleName             = '';
+  /** @var string */
+  protected $actionName             = '';
+  /** @var sfContext */
+  protected $context                = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher             = null;
+  /** @var sfRequest */
+  protected $request                = null;
+  /** @var sfResponse */
+  protected $response               = null;
+  /** @var sfParameterHolder */
+  protected $varHolder              = null;
+  /** @var sfParameterHolder */
+  protected $requestParameterHolder = null;
 
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfContext $context
+   * @param string $moduleName
+   * @param string $actionName
    */
   public function __construct($context, $moduleName, $actionName)
   {
@@ -251,9 +262,9 @@ abstract class sfComponent
    *
    * <code>$this->getContext()->getRouting()->generate(...)</code>
    *
-   * @param string  The route name
-   * @param array   An array of parameters for the route
-   * @param Boolean Whether to generate an absolute URL or not
+   * @param string  $route    The route name
+   * @param array   $params   An array of parameters for the route
+   * @param Boolean $absolute Whether to generate an absolute URL or not
    *
    * @return string  The URL
    */

--- a/lib/action/sfComponents.class.php
+++ b/lib/action/sfComponents.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -19,6 +19,8 @@
 abstract class sfComponents extends sfComponent
 {
   /**
+   * @param sfRequest $request
+   * @return mixed
    * @throws sfInitializationException
    *
    * @see sfComponent

--- a/lib/addon/sfPager.class.php
+++ b/lib/addon/sfPager.class.php
@@ -62,12 +62,13 @@ abstract class sfPager implements Iterator, Countable
    * @return array
    */
   abstract public function getResults();
-
+  
   /**
    * Returns an object at a certain offset.
    *
    * Used internally by {@link getCurrent()}.
    *
+   * @param int $offset
    * @return mixed
    */
   abstract protected function retrieveObject($offset);

--- a/lib/autoload/sfAutoload.class.php
+++ b/lib/autoload/sfAutoload.class.php
@@ -36,7 +36,7 @@ class sfAutoload
   /**
    * Retrieves the singleton instance of this class.
    *
-   * @return sfCoreAutoload A sfCoreAutoload implementation instance.
+   * @return sfAutoload A sfAutoload implementation instance.
    */
   static public function getInstance()
   {
@@ -47,11 +47,13 @@ class sfAutoload
 
     return self::$instance;
   }
-
+  
   /**
    * Register sfAutoload in spl autoloader.
    *
    * @return void
+   *
+   * @throws sfException
    */
   static public function register()
   {

--- a/lib/autoload/sfCoreAutoload.class.php
+++ b/lib/autoload/sfCoreAutoload.class.php
@@ -53,11 +53,13 @@ class sfCoreAutoload
 
     return self::$instance;
   }
-
+  
   /**
    * Register sfCoreAutoload in spl autoloader.
    *
    * @return void
+   *
+   * @throws sfException If unable to register SPL autoload function
    */
   static public function register()
   {

--- a/lib/autoload/sfSimpleAutoload.class.php
+++ b/lib/autoload/sfSimpleAutoload.class.php
@@ -60,11 +60,13 @@ class sfSimpleAutoload
 
     return self::$instance;
   }
-
+  
   /**
    * Register sfSimpleAutoload in spl autoloader.
    *
    * @return void
+   *
+   * @throws sfException
    */
   static public function register()
   {
@@ -326,7 +328,7 @@ class sfSimpleAutoload
    * Loads configuration from the supplied files.
    *
    * @param array $files An array of autoload.yml files
-   * 
+   *
    * @see sfAutoloadConfigHandler
    */
   public function loadConfiguration(array $files)

--- a/lib/cache/sfAPCCache.class.php
+++ b/lib/cache/sfAPCCache.class.php
@@ -19,7 +19,7 @@
 class sfAPCCache extends sfCache
 {
   protected $enabled;
-
+  
   /**
    * Initializes this sfCache instance.
    *
@@ -28,6 +28,7 @@ class sfAPCCache extends sfCache
    * * see sfCache for options available for all drivers
    *
    * @see sfCache
+   * @inheritdoc
    */
   public function initialize($options = array())
   {
@@ -35,10 +36,11 @@ class sfAPCCache extends sfCache
 
     $this->enabled = function_exists('apc_store') && ini_get('apc.enabled');
   }
-
- /**
-  * @see sfCache
-  */
+  
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
   public function get($key, $default = null)
   {
     if (!$this->enabled)
@@ -50,9 +52,10 @@ class sfAPCCache extends sfCache
 
     return $has ? $value : $default;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
@@ -82,10 +85,11 @@ class sfAPCCache extends sfCache
 
     return $value;
   }
-
-
+  
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
@@ -96,9 +100,10 @@ class sfAPCCache extends sfCache
 
     return apc_store($this->getOption('prefix').$key, $data, $this->getLifetime($lifetime));
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
@@ -109,9 +114,10 @@ class sfAPCCache extends sfCache
 
     return apc_delete($this->getOption('prefix').$key);
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -125,9 +131,10 @@ class sfAPCCache extends sfCache
       return apc_clear_cache('user');
     }
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -138,9 +145,10 @@ class sfAPCCache extends sfCache
 
     return 0;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {
@@ -151,9 +159,10 @@ class sfAPCCache extends sfCache
 
     return 0;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {

--- a/lib/cache/sfCache.class.php
+++ b/lib/cache/sfCache.class.php
@@ -24,11 +24,13 @@ abstract class sfCache
 
   protected
     $options = array();
-
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param array $options
    */
   public function __construct($options = array())
   {
@@ -116,9 +118,9 @@ abstract class sfCache
   /**
    * Cleans the cache.
    *
-   * @param string $mode The clean mode
-   *                     sfCache::ALL: remove all keys (default)
-   *                     sfCache::OLD: remove all expired keys
+   * @param int $mode The clean mode
+   *                  sfCache::ALL: remove all keys (default)
+   *                  sfCache::OLD: remove all expired keys
    *
    * @return Boolean true if no problem
    */
@@ -138,7 +140,7 @@ abstract class sfCache
    *
    * @param string $key The cache key
    *
-   * @return int The last modified time
+   * @return int The last modified time (timestamp)
    */
   abstract public function getLastModified($key);
 
@@ -171,11 +173,13 @@ abstract class sfCache
   {
     return null === $lifetime ? $this->getOption('lifetime') : $lifetime;
   }
-
+  
   /**
    * Gets the backend object.
    *
-   * @return object The backend object
+   * @return mixed The backend object
+   *
+   * @throws sfException
    */
   public function getBackend()
   {
@@ -194,12 +198,14 @@ abstract class sfCache
   {
     return isset($this->options[$name]) ? $this->options[$name] : $default;
   }
-
+  
   /**
    * Sets an option value.
    *
    * @param string $name  The option name
    * @param mixed  $value The option value
+   *
+   * @return mixed
    */
   public function setOption($name, $value)
   {

--- a/lib/cache/sfEAcceleratorCache.class.php
+++ b/lib/cache/sfEAcceleratorCache.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -26,6 +26,10 @@ class sfEAcceleratorCache extends sfCache
    * * see sfCache for options available for all drivers
    *
    * @see sfCache
+   *
+   * @param  array $options
+   *
+   * @throws sfInitializationException
    */
   public function initialize($options = array())
   {
@@ -36,43 +40,60 @@ class sfEAcceleratorCache extends sfCache
       throw new sfInitializationException('You must have EAccelerator installed and enabled to use sfEAcceleratorCache class (or perhaps you forgot to add --with-eaccelerator-shared-memory when installing).');
     }
   }
-
- /**
-  * @see sfCache
-  */
+  
+  /**
+   * @see sfCache
+   *
+   * @param string $key
+   * @param mixed  $default
+   *
+   * @return null|string
+   */
   public function get($key, $default = null)
   {
     $value = eaccelerator_get($this->getOption('prefix').$key);
 
     return null === $value ? $default : $value;
   }
-
+  
   /**
    * @see sfCache
+   *
+   * @param string $key
+   *
+   * @return bool
    */
   public function has($key)
   {
     return null !== eaccelerator_get($this->getOption('prefix'.$key));
   }
-
+  
   /**
    * @see sfCache
+   *
+   * @param  string   $key
+   * @param  string   $data
+   * @param  int|null $lifetime
+   *
+   * @return bool
    */
   public function set($key, $data, $lifetime = null)
   {
     return eaccelerator_put($this->getOption('prefix').$key, $data, $this->getLifetime($lifetime));
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
     return eaccelerator_rm($this->getOption('prefix').$key);
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {
@@ -91,9 +112,10 @@ class sfEAcceleratorCache extends sfCache
       }
     }
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -121,9 +143,10 @@ class sfEAcceleratorCache extends sfCache
 
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -134,9 +157,10 @@ class sfEAcceleratorCache extends sfCache
 
     return 0;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {

--- a/lib/cache/sfFileCache.class.php
+++ b/lib/cache/sfFileCache.class.php
@@ -23,18 +23,19 @@ class sfFileCache extends sfCache
   const READ_LAST_MODIFIED = 4;
 
   const EXTENSION = '.cache';
-
- /**
-  * Initializes this sfCache instance.
-  *
-  * Available options:
-  *
-  * * cache_dir: The directory where to put cache files
-  *
-  * * see sfCache for options available for all drivers
-  *
-  * @see sfCache
-  */
+  
+  /**
+   * Initializes this sfCache instance.
+   *
+   * Available options:
+   *
+   * * cache_dir: The directory where to put cache files
+   *
+   * * see sfCache for options available for all drivers
+   *
+   * @see sfCache
+   * @inheritdoc
+   */
   public function initialize($options = array())
   {
     parent::initialize($options);
@@ -46,9 +47,10 @@ class sfFileCache extends sfCache
 
     $this->setcache_dir($this->getOption('cache_dir'));
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function get($key, $default = null)
   {
@@ -67,9 +69,10 @@ class sfFileCache extends sfCache
 
     return $data[self::READ_DATA];
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
@@ -77,9 +80,10 @@ class sfFileCache extends sfCache
 
     return is_file($path) && $this->isValid($path);
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
@@ -90,17 +94,19 @@ class sfFileCache extends sfCache
 
     return $this->write($this->getFilePath($key), $data, time() + $this->getLifetime($lifetime));
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
     return @unlink($this->getFilePath($key));
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {
@@ -135,9 +141,10 @@ class sfFileCache extends sfCache
       }
     }
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -157,9 +164,10 @@ class sfFileCache extends sfCache
 
     return $result;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {
@@ -174,9 +182,10 @@ class sfFileCache extends sfCache
 
     return $data[self::READ_TIMEOUT] < time() ? 0 : $data[self::READ_TIMEOUT];
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {

--- a/lib/cache/sfFunctionCache.class.php
+++ b/lib/cache/sfFunctionCache.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -29,7 +29,7 @@ class sfFunctionCache
   {
     $this->cache = $cache;
   }
-
+  
   /**
    * Calls a cacheable function or method (or not if there is already a cache for it).
    *
@@ -42,8 +42,10 @@ class sfFunctionCache
    *
    * @param mixed $callable  A PHP callable
    * @param array $arguments An array of arguments to pass to the callable
-   *
    * @return mixed The result of the function/method
+   *
+   * @throws Exception
+   * @throws sfException
    */
   public function call($callable, $arguments = array())
   {

--- a/lib/cache/sfMemcacheCache.class.php
+++ b/lib/cache/sfMemcacheCache.class.php
@@ -18,9 +18,9 @@
  */
 class sfMemcacheCache extends sfCache
 {
-  protected
-    $memcache = null;
-
+  /** @var Memcache */
+  protected $memcache = null;
+  
   /**
    * Initializes this sfCache instance.
    *
@@ -37,6 +37,7 @@ class sfMemcacheCache extends sfCache
    * * see sfCache for options available for all drivers
    *
    * @see sfCache
+   * @inheritdoc
    */
   public function initialize($options = array())
   {
@@ -79,24 +80,27 @@ class sfMemcacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @return Memcache
    */
   public function getBackend()
   {
     return $this->memcache;
   }
-
- /**
-  * @see sfCache
-  */
+  
+  /**
+   * @see sfCache
+   * @inheritdoc
+   */
   public function get($key, $default = null)
   {
     $value = $this->memcache->get($this->getOption('prefix').$key);
 
     return (false === $value && false === $this->getMetadata($key)) ? $default : $value;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
@@ -108,9 +112,10 @@ class sfMemcacheCache extends sfCache
 
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
@@ -132,9 +137,10 @@ class sfMemcacheCache extends sfCache
 
     return $this->memcache->set($this->getOption('prefix').$key, $data, false, time() + $lifetime);
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
@@ -146,9 +152,10 @@ class sfMemcacheCache extends sfCache
     }
     return $this->memcache->delete($this->getOption('prefix').$key, 0);
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -157,9 +164,10 @@ class sfMemcacheCache extends sfCache
       return $this->memcache->flush();
     }
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -170,9 +178,10 @@ class sfMemcacheCache extends sfCache
 
     return $retval['lastModified'];
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {
@@ -183,9 +192,12 @@ class sfMemcacheCache extends sfCache
 
     return $retval['timeout'];
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
+   *
+   * @throws sfCacheException
    */
   public function removePattern($pattern)
   {
@@ -203,9 +215,10 @@ class sfMemcacheCache extends sfCache
       }
     }
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getMany($keys)
   {
@@ -275,6 +288,8 @@ class sfMemcacheCache extends sfCache
 
   /**
    * Gets cache information.
+   *
+   * @return array
    */
   protected function getCacheInfo()
   {

--- a/lib/cache/sfNoCache.class.php
+++ b/lib/cache/sfNoCache.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -20,54 +20,61 @@ class sfNoCache extends sfCache
 {
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function get($key, $default = null)
   {
     return $default;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
     return false;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = self::ALL)
   {
     return true;
   }
-
+  
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -76,6 +83,7 @@ class sfNoCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {

--- a/lib/cache/sfSQLiteCache.class.php
+++ b/lib/cache/sfSQLiteCache.class.php
@@ -33,6 +33,7 @@ class sfSQLiteCache extends sfCache
    * * see sfCache for options available for all drivers
    *
    * @see sfCache
+   * @inheritdoc
    */
   public function initialize($options = array())
   {
@@ -53,6 +54,8 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdo
+   * @return SQLiteDatabase|SQLite3
    */
   public function getBackend()
   {
@@ -61,6 +64,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function get($key, $default = null)
   {
@@ -78,6 +82,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
@@ -91,6 +96,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
@@ -109,6 +115,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
@@ -122,6 +129,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {
@@ -135,6 +143,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -155,6 +164,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {
@@ -172,6 +182,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -186,11 +197,13 @@ class sfSQLiteCache extends sfCache
 
     return $rs->numRows() ? (int) $rs->fetchSingle() : 0;
   }
-
+  
   /**
    * Sets the database name.
    *
    * @param string $database The database name where to store the cache
+   *
+   * @throws sfCacheException
    */
   protected function setDatabase($database)
   {
@@ -240,9 +253,12 @@ class sfSQLiteCache extends sfCache
       $this->createSchema();
     }
   }
-
+  
   /**
    * Callback used when deleting keys from cache.
+   * @param string $regexp
+   * @param string $key
+   * @return int
    */
   public function removePatternRegexpCallback($regexp, $key)
   {
@@ -251,6 +267,7 @@ class sfSQLiteCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getMany($keys)
   {

--- a/lib/cache/sfXCacheCache.class.php
+++ b/lib/cache/sfXCacheCache.class.php
@@ -26,6 +26,7 @@ class sfXCacheCache extends sfCache
    * * see sfCache for options available for all drivers
    *
    * @see sfCache
+   * @inheritdoc
    */
   public function initialize($options = array())
   {
@@ -44,6 +45,7 @@ class sfXCacheCache extends sfCache
 
  /**
   * @see sfCache
+  * @inheritdoc
   */
   public function get($key, $default = null)
   {
@@ -61,6 +63,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function has($key)
   {
@@ -69,6 +72,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function set($key, $data, $lifetime = null)
   {
@@ -85,6 +89,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function remove($key)
   {
@@ -93,6 +98,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function clean($mode = sfCache::ALL)
   {
@@ -116,6 +122,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getLastModified($key)
   {
@@ -132,6 +139,7 @@ class sfXCacheCache extends sfCache
 
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function getTimeout($key)
   {
@@ -147,6 +155,10 @@ class sfXCacheCache extends sfCache
     return $set['timeout'];
   }
   
+  /**
+   * @param string $key
+   * @return mixed|null
+   */
   public function getBaseValue($key)
   {
     return xcache_isset($this->getOption('prefix').$key) ? xcache_get($this->getOption('prefix').$key) : null;
@@ -154,6 +166,7 @@ class sfXCacheCache extends sfCache
   
   /**
    * @see sfCache
+   * @inheritdoc
    */
   public function removePattern($pattern)
   {
@@ -178,7 +191,11 @@ class sfXCacheCache extends sfCache
       }
     }
   }
-
+  
+  /**
+   * @param string $key
+   * @return array|null
+   */
   public function getCacheInfo($key)
   {
     $this->checkAuth();

--- a/lib/command/sfAnsiColorFormatter.class.php
+++ b/lib/command/sfAnsiColorFormatter.class.php
@@ -79,14 +79,16 @@ class sfAnsiColorFormatter extends sfFormatter
 
     return "\033[".implode(';', $codes).'m'.$text."\033[0m";
   }
-
+  
   /**
    * Formats a message within a section.
    *
-   * @param string  $section  The section name
-   * @param string  $text     The text message
-   * @param integer $size     The maximum size allowed for a line
-   * @param string  $style    The color scheme to apply to the section string (INFO, ERROR, COMMENT or QUESTION)
+   * @param string  $section The section name
+   * @param string  $text    The text message
+   * @param integer $size    The maximum size allowed for a line
+   * @param string  $style   The color scheme to apply to the section string (INFO, ERROR, COMMENT or QUESTION)
+   *
+   * @return string
    */
   public function formatSection($section, $text, $size = null, $style = 'INFO')
   {

--- a/lib/command/sfCommandApplication.class.php
+++ b/lib/command/sfCommandApplication.class.php
@@ -18,19 +18,32 @@
  */
 abstract class sfCommandApplication
 {
-  protected
-    $commandManager = null,
-    $trace          = false,
-    $verbose        = true,
-    $debug          = true,
-    $nowrite        = false,
-    $name           = 'UNKNOWN',
-    $version        = 'UNKNOWN',
-    $tasks          = array(),
-    $currentTask    = null,
-    $dispatcher     = null,
-    $options        = array(),
-    $formatter      = null;
+  /** @var sfCommandManager */
+  protected $commandManager = null;
+  /** @var bool */
+  protected $trace = false;
+  /** @var bool */
+  protected $verbose = true;
+  /** @var bool */
+  protected $debug = true;
+  /** @var bool */
+  protected $nowrite = false;
+  /** @var string */
+  protected $name = 'UNKNOWN';
+  /** @var string */
+  protected $version = 'UNKNOWN';
+  /** @var array */
+  protected $tasks = array();
+  /** @var sfTask */
+  protected $currentTask = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var array */
+  protected $options = array();
+  /** @var sfFormatter */
+  protected $formatter = null;
+  /** @var mixed */
+  protected $commandOptions;
 
   /**
    * Constructor.
@@ -95,7 +108,7 @@ abstract class sfCommandApplication
   /**
    * Sets the formatter instance.
    *
-   * @param sfFormatter The formatter instance
+   * @param sfFormatter $formatter The formatter instance
    */
   public function setFormatter(sfFormatter $formatter)
   {
@@ -131,11 +144,13 @@ abstract class sfCommandApplication
       $this->registerTask($task);
     }
   }
-
+  
   /**
    * Registers a task object.
    *
    * @param sfTask $task An sfTask object
+   *
+   * @throws sfCommandException
    */
   public function registerTask(sfTask $task)
   {
@@ -187,13 +202,15 @@ abstract class sfCommandApplication
   {
     return $this->tasks;
   }
-
+  
   /**
    * Returns a registered task by name or alias.
    *
    * @param string $name The task name or alias
    *
    * @return sfTask An sfTask object
+   *
+   * @throws sfCommandException
    */
   public function getTask($name)
   {
@@ -447,13 +464,15 @@ abstract class sfCommandApplication
 
     $this->dispatcher->notify(new sfEvent($e, 'application.throw_exception'));
   }
-
+  
   /**
    * Gets a task from a task name or a shortcut.
    *
-   * @param  string  $name  The task name or a task shortcut
+   * @param  string $name The task name or a task shortcut
    *
    * @return sfTask A sfTask object
+   *
+   * @throws sfCommandException
    */
   public function getTaskToExecute($name)
   {
@@ -589,11 +608,15 @@ abstract class sfCommandApplication
     // close the streams on script termination
     register_shutdown_function(create_function('', 'fclose(STDIN); fclose(STDOUT); fclose(STDERR); return true;'));
   }
-
+  
   /**
    * Returns an array of possible abbreviations given a set of names.
    *
    * @see Text::Abbrev perl module for the algorithm
+   *
+   * @param string[] $names
+   *
+   * @return string[]
    */
   protected function getAbbreviations($names)
   {

--- a/lib/command/sfCommandArgument.class.php
+++ b/lib/command/sfCommandArgument.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -28,7 +28,7 @@ class sfCommandArgument
     $mode    = null,
     $default = null,
     $help    = '';
-
+  
   /**
    * Constructor.
    *
@@ -36,6 +36,8 @@ class sfCommandArgument
    * @param integer $mode    The argument mode: self::REQUIRED or self::OPTIONAL
    * @param string  $help    A help text
    * @param mixed   $default The default value (for self::OPTIONAL mode only)
+   *
+   * @throws sfCommandException
    */
   public function __construct($name, $mode = null, $help = '', $default = null)
   {
@@ -84,11 +86,13 @@ class sfCommandArgument
   {
     return self::IS_ARRAY === (self::IS_ARRAY & $this->mode);
   }
-
+  
   /**
    * Sets the default value.
    *
    * @param mixed $default The default value
+   *
+   * @throws sfCommandException
    */
   public function setDefault($default = null)
   {

--- a/lib/command/sfCommandArgumentSet.class.php
+++ b/lib/command/sfCommandArgumentSet.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -62,11 +62,13 @@ class sfCommandArgumentSet
       }
     }
   }
-
+  
   /**
    * Add a sfCommandArgument objects.
    *
    * @param sfCommandArgument $argument A sfCommandArgument object
+   *
+   * @throws sfCommandException
    */
   public function addArgument(sfCommandArgument $argument)
   {
@@ -101,13 +103,15 @@ class sfCommandArgumentSet
 
     $this->arguments[$argument->getName()] = $argument;
   }
-
+  
   /**
    * Returns an argument by name.
    *
    * @param string $name The argument name
    *
    * @return sfCommandArgument A sfCommandArgument object
+   *
+   * @throws sfCommandException
    */
   public function getArgument($name)
   {
@@ -134,7 +138,7 @@ class sfCommandArgumentSet
   /**
    * Gets the array of sfCommandArgument objects.
    *
-   * @return array An array of sfCommandArgument objects
+   * @return sfCommandArgument[] An array of sfCommandArgument objects
    */
   public function getArguments()
   {

--- a/lib/command/sfCommandManager.class.php
+++ b/lib/command/sfCommandManager.class.php
@@ -18,14 +18,20 @@
  */
 class sfCommandManager
 {
-  protected
-    $arguments            = '',
-    $errors               = array(),
-    $optionSet            = null,
-    $argumentSet          = array(),
-    $optionValues         = array(),
-    $argumentValues       = array(),
-    $parsedArgumentValues = array();
+  /** @var array */
+  protected $arguments = '';
+  /** @var string[] */
+  protected $errors = array();
+  /** @var sfCommandOptionSet */
+  protected $optionSet = null;
+  /** @var sfCommandArgumentSet */
+  protected $argumentSet = array();
+  /** @var array */
+  protected $optionValues = array();
+  /** @var array */
+  protected $argumentValues = array();
+  /** @var array */
+  protected $parsedArgumentValues = array();
 
   /**
    * Constructor.
@@ -203,13 +209,15 @@ class sfCommandManager
   {
     return $this->argumentValues;
   }
-
+  
   /**
    * Returns the argument value for a given argument name.
    *
    * @param string $name The argument name
    *
    * @return mixed The argument value
+   *
+   * @throws sfCommandException
    */
   public function getArgumentValue($name)
   {
@@ -230,13 +238,15 @@ class sfCommandManager
   {
     return $this->optionValues;
   }
-
+  
   /**
    * Returns the option value for a given option name.
    *
    * @param string $name The option name
    *
    * @return mixed The option value
+   *
+   * @throws sfCommandException
    */
   public function getOptionValue($name)
   {

--- a/lib/command/sfCommandOption.class.php
+++ b/lib/command/sfCommandOption.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -30,7 +30,7 @@ class sfCommandOption
     $mode     = null,
     $default  = null,
     $help     = '';
-
+  
   /**
    * Constructor.
    *
@@ -39,6 +39,8 @@ class sfCommandOption
    * @param integer $mode     The option mode: self::PARAMETER_REQUIRED, self::PARAMETER_NONE or self::PARAMETER_OPTIONAL
    * @param string  $help     A help text
    * @param mixed   $default  The default value (must be null for self::PARAMETER_REQUIRED or self::PARAMETER_NONE)
+   *
+   * @throws sfCommandException
    */
   public function __construct($name, $shortcut = null, $mode = null, $help = '', $default = null)
   {
@@ -136,11 +138,13 @@ class sfCommandOption
   {
     return self::IS_ARRAY === (self::IS_ARRAY & $this->mode);
   }
-
+  
   /**
    * Sets the default value.
    *
    * @param mixed $default The default value
+   *
+   * @throws sfCommandException
    */
   public function setDefault($default = null)
   {

--- a/lib/command/sfCommandOptionSet.class.php
+++ b/lib/command/sfCommandOptionSet.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -56,11 +56,13 @@ class sfCommandOptionSet
       $this->addOption($option);
     }
   }
-
+  
   /**
    * Add a sfCommandOption objects.
    *
    * @param sfCommandOption $option A sfCommandOption object
+   *
+   * @throws sfCommandException
    */
   public function addOption(sfCommandOption $option)
   {
@@ -79,13 +81,15 @@ class sfCommandOptionSet
       $this->shortcuts[$option->getShortcut()] = $option->getName();
     }
   }
-
+  
   /**
    * Returns an option by name.
    *
    * @param string $name The option name
    *
    * @return sfCommandOption A sfCommandOption object
+   *
+   * @throws sfCommandException
    */
   public function getOption($name)
   {
@@ -112,7 +116,7 @@ class sfCommandOptionSet
   /**
    * Gets the array of sfCommandOption objects.
    *
-   * @return array An array of sfCommandOption objects
+   * @return sfCommandOption[] An array of sfCommandOption objects
    */
   public function getOptions()
   {
@@ -130,9 +134,11 @@ class sfCommandOptionSet
   {
     return isset($this->shortcuts[$name]);
   }
-
+  
   /**
    * Gets an option by shortcut.
+   *
+   * @param string $shortcut
    *
    * @return sfCommandOption A sfCommandOption object
    */
@@ -156,13 +162,15 @@ class sfCommandOptionSet
 
     return $values;
   }
-
+  
   /**
    * Returns the option name given a shortcut.
    *
    * @param string $shortcut The shortcut
    *
    * @return string The option name
+   *
+   * @throws sfCommandException
    */
   protected function shortcutToName($shortcut)
   {

--- a/lib/command/sfFormatter.class.php
+++ b/lib/command/sfFormatter.class.php
@@ -61,13 +61,15 @@ class sfFormatter
   {
     return $text;
   }
-
+  
   /**
    * Formats a message within a section.
    *
-   * @param string  $section  The section name
-   * @param string  $text     The text message
-   * @param integer $size     The maximum size allowed for a line
+   * @param string  $section The section name
+   * @param string  $text    The text message
+   * @param integer $size    The maximum size allowed for a line
+   *
+   * @return string
    */
   public function formatSection($section, $text, $size = null)
   {

--- a/lib/config/sfAutoloadConfigHandler.class.php
+++ b/lib/config/sfAutoloadConfigHandler.class.php
@@ -148,6 +148,7 @@ class sfAutoloadConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfCacheConfigHandler.class.php
+++ b/lib/config/sfCacheConfigHandler.class.php
@@ -106,6 +106,7 @@ class sfCacheConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfCompileConfigHandler.class.php
+++ b/lib/config/sfCompileConfigHandler.class.php
@@ -79,6 +79,7 @@ class sfCompileConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfConfigCache.class.php
+++ b/lib/config/sfConfigCache.class.php
@@ -134,7 +134,7 @@ class sfConfigCache
    *
    * The recompilation only occurs in a non debug environment.
    *
-   * If the configuration file path is relative, symfony will look in directories 
+   * If the configuration file path is relative, symfony will look in directories
    * defined in the sfConfiguration::getConfigPaths() method.
    *
    * @param string  $configPath A filesystem path to a configuration file
@@ -199,6 +199,7 @@ class sfConfigCache
 
     if (sfConfig::get('sf_debug') && sfConfig::get('sf_logging_enabled'))
     {
+      /** @var $timer sfTimer */
       $timer->addTime();
     }
 
@@ -377,7 +378,7 @@ class sfConfigCache
   }
 
   /**
-   * Merges configuration handlers from the config_handlers.yml  
+   * Merges configuration handlers from the config_handlers.yml
    * and the ones defined with registerConfigHandler()
    *
    */

--- a/lib/config/sfConfigHandler.class.php
+++ b/lib/config/sfConfigHandler.class.php
@@ -22,13 +22,15 @@
  */
 abstract class sfConfigHandler
 {
+  /** @var sfParameterHolder */
   protected
     $parameterHolder = null;
-
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   * @param array|null $parameters
    */
   public function __construct($parameters = null)
   {
@@ -40,7 +42,7 @@ abstract class sfConfigHandler
    *
    * @param array $parameters An associative array of initialization parameters
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this ConfigHandler
    */
@@ -69,7 +71,7 @@ abstract class sfConfigHandler
    *
    * @param mixed $value The value on which to run the replacement procedure
    *
-   * @return string The new value
+   * @return string|mixed|array The new value
    */
   static public function replaceConstants($value)
   {

--- a/lib/config/sfDatabaseConfigHandler.class.php
+++ b/lib/config/sfDatabaseConfigHandler.class.php
@@ -131,6 +131,7 @@ class sfDatabaseConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfDefineEnvironmentConfigHandler.class.php
+++ b/lib/config/sfDefineEnvironmentConfigHandler.class.php
@@ -140,6 +140,7 @@ class sfDefineEnvironmentConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfFactoryConfigHandler.class.php
+++ b/lib/config/sfFactoryConfigHandler.class.php
@@ -246,6 +246,7 @@ class sfFactoryConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfFilterConfigHandler.class.php
+++ b/lib/config/sfFilterConfigHandler.class.php
@@ -166,6 +166,7 @@ EOF;
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfGeneratorConfigHandler.class.php
+++ b/lib/config/sfGeneratorConfigHandler.class.php
@@ -84,6 +84,7 @@ class sfGeneratorConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfProjectConfiguration.class.php
+++ b/lib/config/sfProjectConfiguration.class.php
@@ -18,18 +18,25 @@
  */
 class sfProjectConfiguration
 {
-  protected
-    $rootDir               = null,
-    $symfonyLibDir         = null,
-    $dispatcher            = null,
-    $plugins               = array(),
-    $pluginPaths           = array(),
-    $overriddenPluginPaths = array(),
-    $pluginConfigurations  = array(),
-    $pluginsLoaded         = false;
+  /** @var string */
+  protected $rootDir = null;
+  /** @var string */
+  protected $symfonyLibDir = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var array */
+  protected $plugins = array();
+  /** @var array */
+  protected $pluginPaths = array();
+  /** @var array */
+  protected $overriddenPluginPaths = array();
+  /** @var sfPluginConfiguration[] */
+  protected $pluginConfigurations = array();
+  /** @var bool */
+  protected $pluginsLoaded = false;
 
-  static protected
-    $active = null;
+  /** @var sfApplicationConfiguration|sfProjectConfiguration */
+  static protected $active = null;
 
   /**
    * Constructor.
@@ -614,14 +621,16 @@ class sfProjectConfiguration
 
     return new $class($environment, $debug, $rootDir, $dispatcher);
   }
-
+  
   /**
    * Calls methods defined via sfEventDispatcher.
    *
-   * @param string $method The method name
+   * @param string $method    The method name
    * @param array  $arguments The method arguments
    *
    * @return mixed The returned value of the called method
+   *
+   * @throws sfException
    */
   public function __call($method, $arguments)
   {

--- a/lib/config/sfRoutingConfigHandler.class.php
+++ b/lib/config/sfRoutingConfigHandler.class.php
@@ -35,6 +35,7 @@ class sfRoutingConfigHandler extends sfYamlConfigHandler
     foreach ($this->parse($configFiles) as $name => $routeConfig)
     {
       $r = new ReflectionClass($routeConfig[0]);
+      /** @var sfRoute $route */
       $route = $r->newInstanceArgs($routeConfig[1]);
 
       $routes = $route instanceof sfRouteCollection ? $route : array($name => $route);

--- a/lib/config/sfSecurityConfigHandler.class.php
+++ b/lib/config/sfSecurityConfigHandler.class.php
@@ -45,6 +45,7 @@ class sfSecurityConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfServiceConfigHandler.class.php
+++ b/lib/config/sfServiceConfigHandler.class.php
@@ -57,6 +57,7 @@ class sfServiceConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfSimpleYamlConfigHandler.class.php
+++ b/lib/config/sfSimpleYamlConfigHandler.class.php
@@ -40,6 +40,7 @@ class sfSimpleYamlConfigHandler extends sfYamlConfigHandler
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfViewConfigHandler.class.php
+++ b/lib/config/sfViewConfigHandler.class.php
@@ -248,11 +248,12 @@ EOF;
 
     return implode("\n", array_merge($css, $js))."\n";
   }
-
+  
   /**
    * Creates a list of add$Type PHP statements for the given type and config.
    *
    * @param string $type of asset. Requires an sfWebResponse->add$Type(string, string, array) method
+   * @param array  $assets
    *
    * @return array ist of add$Type PHP statements
    */
@@ -317,6 +318,7 @@ EOF;
 
   /**
    * @see sfConfigHandler
+   * @inheritdoc
    */
   static public function getConfiguration(array $configFiles)
   {

--- a/lib/config/sfYamlConfigHandler.class.php
+++ b/lib/config/sfYamlConfigHandler.class.php
@@ -19,8 +19,8 @@
  */
 abstract class sfYamlConfigHandler extends sfConfigHandler
 {
-  protected
-    $yamlConfig = null;
+  /** @var array */
+  protected $yamlConfig = null;
 
   /**
    * Parses an array of YAMLs files and merges them in one configuration array.
@@ -55,7 +55,7 @@ abstract class sfYamlConfigHandler extends sfConfigHandler
    *
    * @param string $configFile An absolute filesystem path to a configuration file
    *
-   * @return string A parsed .yml configuration
+   * @return string|array A parsed .yml configuration
    *
    * @throws sfConfigurationException If a requested configuration file does not exist or is not readable
    * @throws sfParseException If a requested configuration file is improperly formatted

--- a/lib/controller/sfController.class.php
+++ b/lib/controller/sfController.class.php
@@ -20,17 +20,20 @@
  */
 abstract class sfController
 {
-  protected
-    $context           = null,
-    $dispatcher        = null,
-    $controllerClasses = array(),
-    $renderMode        = sfView::RENDER_CLIENT,
-    $maxForwards       = 5;
-
+  /** @var sfContext */
+  protected $context = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var string[] */
+  protected $controllerClasses = array();
+  protected $renderMode = sfView::RENDER_CLIENT;
+  protected $maxForwards = 5;
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   * @param sfContext $context A sfContext implementation instance
    */
   public function __construct($context)
   {
@@ -285,7 +288,7 @@ abstract class sfController
    * @param string $controllerName A component name
    * @param string $extension      Either 'action' or 'component' depending on the type of controller to look for
    *
-   * @return object A controller implementation instance, if the controller exists, otherwise null
+   * @return sfAction A controller implementation instance, if the controller exists, otherwise null
    *
    * @see getComponent(), getAction()
    */
@@ -368,7 +371,7 @@ abstract class sfController
 
     return new $class($this->context, $moduleName, $actionName, $viewName);
   }
-
+  
   /**
    * Returns the rendered view presentation of a given module/action.
    *
@@ -377,6 +380,9 @@ abstract class sfController
    * @param string $viewName A View class name
    *
    * @return string The generated content
+   *
+   * @throws Exception
+   * @throws sfException
    */
   public function getPresentationFor($module, $action, $viewName = null)
   {
@@ -465,7 +471,7 @@ abstract class sfController
    *                  - sfView::RENDER_VAR
    *                  - sfView::RENDER_NONE
    *
-   * @return true
+   * @return void
    *
    * @throws sfRenderException If an invalid render mode has been set
    */
@@ -491,7 +497,7 @@ abstract class sfController
   {
     return 'cli' == PHP_SAPI;
   }
-
+  
   /**
    * Calls methods defined via sfEventDispatcher.
    *
@@ -499,6 +505,8 @@ abstract class sfController
    * @param array  $arguments The method arguments
    *
    * @return mixed The returned value of the called method
+   *
+   * @throws sfException
    */
   public function __call($method, $arguments)
   {

--- a/lib/controller/sfFrontWebController.class.php
+++ b/lib/controller/sfFrontWebController.class.php
@@ -35,6 +35,7 @@ class sfFrontWebController extends sfWebController
       sfFilter::$filterCalled = array();
 
       // determine our module and action
+      /** @var sfWebRequest $request */
       $request    = $this->context->getRequest();
       $moduleName = $request->getParameter('module');
       $actionName = $request->getParameter('action');

--- a/lib/controller/sfWebController.class.php
+++ b/lib/controller/sfWebController.class.php
@@ -80,13 +80,15 @@ abstract class sfWebController extends sfController
 
     return $url;
   }
-
+  
   /**
    * Converts an internal URI string to an array of parameters.
    *
    * @param string $url An internal URI
    *
    * @return array An array of parameters
+   *
+   * @throws sfParseException
    */
   public function convertUrlStringToParameters($url)
   {
@@ -177,7 +179,7 @@ abstract class sfWebController extends sfController
   {
     if (empty($url))
     {
-      throw new InvalidArgumentException('Cannot redirect to an empty URL.'); 
+      throw new InvalidArgumentException('Cannot redirect to an empty URL.');
     }
 
     $url = $this->genUrl($url, true);
@@ -190,6 +192,7 @@ abstract class sfWebController extends sfController
     }
 
     // redirect
+    /** @var sfWebResponse $response */
     $response = $this->context->getResponse();
     $response->clearHttpHeaders();
     $response->setStatusCode($statusCode);

--- a/lib/database/sfDatabase.class.php
+++ b/lib/database/sfDatabase.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -21,15 +21,19 @@
  */
 abstract class sfDatabase
 {
-  protected
-    $parameterHolder = null,
-    $connection      = null,
-    $resource        = null;
-
+  /** @var sfParameterHolder */
+  protected $parameterHolder = null;
+  /** @var resource|PDO */
+  protected $connection = null;
+  /** @var resource|PDO (It's interchangeable with $connection. Can be dropped at all.) */
+  protected $resource = null;
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param array $parameters An associative array of initialization parameters
    */
   public function __construct($parameters = array())
   {
@@ -41,7 +45,7 @@ abstract class sfDatabase
    *
    * @param array $parameters An associative array of initialization parameters
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfDatabase object
    */

--- a/lib/database/sfDatabaseManager.class.php
+++ b/lib/database/sfDatabaseManager.class.php
@@ -22,14 +22,17 @@
  */
 class sfDatabaseManager
 {
-  protected
-    $configuration = null,
-    $databases     = array();
-
+  /** @var sfProjectConfiguration */
+  protected $configuration = null;
+  protected $databases = array();
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfProjectConfiguration $configuration
+   * @param array                  $options
    */
   public function __construct(sfProjectConfiguration $configuration, $options = array())
   {
@@ -46,7 +49,7 @@ class sfDatabaseManager
    *
    * @param sfProjectConfiguration $configuration A sfProjectConfiguration instance
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfDatabaseManager object
    */

--- a/lib/database/sfMySQLiDatabase.class.php
+++ b/lib/database/sfMySQLiDatabase.class.php
@@ -12,6 +12,8 @@
 /**
  * sfMySQLiDatabase provides connectivity for the MySQL brand database.
  * @see sfMySQLDatabase
+ *
+ * @property $connection mysqli
  */
 class sfMySQLiDatabase extends sfMySQLDatabase
 {

--- a/lib/debug/sfDebug.class.php
+++ b/lib/debug/sfDebug.class.php
@@ -44,7 +44,7 @@ class sfDebug
       'extensions' => get_loaded_extensions(),
     );
 
-    natcasesort($values['extensions']); 
+    natcasesort($values['extensions']);
 
     // assign extension version
     if ($values['extensions'])
@@ -124,7 +124,7 @@ class sfDebug
   /**
    * Returns response parameters as an array.
    *
-   * @param sfResponse $response A sfResponse instance
+   * @param sfWebResponse $response A sfResponse instance
    *
    * @return array The response parameters
    */
@@ -251,9 +251,9 @@ class sfDebug
 
   /**
    * Shortens a file path by replacing symfony directory constants.
-   * 
+   *
    * @param  string $file
-   * 
+   *
    * @return string
    */
   static public function shortenFilePath($file)

--- a/lib/debug/sfTimerManager.class.php
+++ b/lib/debug/sfTimerManager.class.php
@@ -18,6 +18,7 @@
  */
 class sfTimerManager
 {
+  /** @var sfTimer[] */
   static public $timers = array();
 
   /**
@@ -47,7 +48,7 @@ class sfTimerManager
   /**
    * Gets all sfTimer instances stored in sfTimerManager.
    *
-   * @return array An array of all sfTimer instances
+   * @return sfTimer[] An array of all sfTimer instances
    */
   public static function getTimers()
   {

--- a/lib/debug/sfTimerManager.class.php
+++ b/lib/debug/sfTimerManager.class.php
@@ -20,13 +20,15 @@ class sfTimerManager
 {
   /** @var sfTimer[] */
   static public $timers = array();
-
+  
   /**
    * Gets a sfTimer instance.
    *
    * It returns the timer named $name or create a new one if it does not exist.
    *
    * @param string $name The name of the timer
+   *
+   * @param bool   $reset
    *
    * @return sfTimer The timer instance
    */

--- a/lib/debug/sfWebDebug.class.php
+++ b/lib/debug/sfWebDebug.class.php
@@ -132,11 +132,12 @@ class sfWebDebug
   {
     unset($this->panels[$name]);
   }
-
+  
   /**
    * Gets an option value by name.
    *
    * @param string $name The option name
+   * @param mixed  $default
    *
    * @return mixed The option value
    */
@@ -269,7 +270,7 @@ class sfWebDebug
   /**
    * Gets the javascript code to inject in the head tag.
    *
-   * @param string The javascript code
+   * @return string The javascript code
    */
   public function getJavascript()
   {
@@ -423,7 +424,7 @@ EOF;
   /**
    * Gets the stylesheet code to inject in the head tag.
    *
-   * @param string The stylesheet code
+   * @return string The stylesheet code
    */
   public function getStylesheet()
   {

--- a/lib/debug/sfWebDebugPanel.class.php
+++ b/lib/debug/sfWebDebugPanel.class.php
@@ -64,7 +64,7 @@ abstract class sfWebDebugPanel
 
   /**
    * Returns the current status.
-   * 
+   *
    * @return integer A {@link sfLogger} priority constant
    */
   public function getStatus()
@@ -74,7 +74,7 @@ abstract class sfWebDebugPanel
 
   /**
    * Sets the current panel's status.
-   * 
+   *
    * @param integer $status A {@link sfLogger} priority constant
    */
   public function setStatus($status)
@@ -84,10 +84,10 @@ abstract class sfWebDebugPanel
 
   /**
    * Returns a toggler element.
-   * 
+   *
    * @param  string $element The value of an element's DOM id attribute
    * @param  string $title   A title attribute
-   * 
+   *
    * @return string
    */
   public function getToggler($element, $title = 'Toggle details')
@@ -97,9 +97,9 @@ abstract class sfWebDebugPanel
 
   /**
    * Returns a toggleable presentation of a debug stack.
-   * 
+   *
    * @param  array $debugStack
-   * 
+   *
    * @return string
    */
   public function getToggleableDebugStack($debugStack)
@@ -144,11 +144,11 @@ abstract class sfWebDebugPanel
 
   /**
    * Formats a file link.
-   * 
+   *
    * @param  string  $file A file path or class name
    * @param  integer $line
    * @param  string  $text Text to use for the link
-   * 
+   *
    * @return string
    */
   public function formatFileLink($file, $line = null, $text = null)
@@ -193,7 +193,7 @@ abstract class sfWebDebugPanel
    * Format a SQL string with some colors on SQL keywords to make it more readable.
    *
    * @param  string $sql    SQL string to format
-   * 
+   *
    * @return string $newSql The new formatted SQL string
    */
   public function formatSql($sql)

--- a/lib/debug/sfWebDebugPanelMailer.class.php
+++ b/lib/debug/sfWebDebugPanelMailer.class.php
@@ -18,6 +18,7 @@
  */
 class sfWebDebugPanelMailer extends sfWebDebugPanel
 {
+  /** @var sfMailer */
   protected $mailer = null;
 
   /**

--- a/lib/escaper/sfOutputEscaperArrayDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperArrayDecorator.class.php
@@ -25,11 +25,12 @@ class sfOutputEscaperArrayDecorator extends sfOutputEscaperGetterDecorator imple
    * @var int
    */
   private $count;
-
+  
   /**
    * Constructor.
    *
    * @see sfOutputEscaper
+   * @inheritdoc
    */
   public function __construct($escapingMethod, $value)
   {

--- a/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
+++ b/lib/escaper/sfOutputEscaperIteratorDecorator.class.php
@@ -54,7 +54,7 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
   /**
    * Resets the iterator (as required by the Iterator interface).
    *
-   * @return bool true, if the iterator rewinds successfully otherwise false
+   * @return void
    */
   public function rewind()
   {
@@ -83,6 +83,8 @@ class sfOutputEscaperIteratorDecorator extends sfOutputEscaperObjectDecorator im
 
   /**
    * Moves to the next element in the iterator (as required by the Iterator interface).
+   *
+   * @return void
    */
   public function next()
   {

--- a/lib/exception/sfException.class.php
+++ b/lib/exception/sfException.class.php
@@ -22,6 +22,7 @@
  */
 class sfException extends Exception
 {
+  /** @var Exception|Throwable|null */
   protected
     $wrappedException = null;
 
@@ -47,7 +48,7 @@ class sfException extends Exception
   /**
    * Sets the wrapped exception.
    *
-   * @param Exception|Throwable $e An Throwable instance
+   * @param Exception|Throwable $e A Throwable instance
    */
   public function setWrappedException($e)
   {
@@ -107,7 +108,7 @@ class sfException extends Exception
       header('HTTP/1.0 500 Internal Server Error');
     }
 
-    if (version_compare(PHP_VERSION, '7.0.0') >= 0) 
+    if (version_compare(PHP_VERSION, '7.0.0') >= 0)
     {
       try
       {
@@ -116,8 +117,8 @@ class sfException extends Exception
       catch (Throwable $e)
       {
       }
-    } 
-    else 
+    }
+    else
     {
       try
       {
@@ -133,9 +134,10 @@ class sfException extends Exception
       exit(1);
     }
   }
-
+  
   /**
    * Gets the stack trace for this exception.
+   * @param Exception|Throwable $exception
    */
   static protected function outputStackTrace($exception)
   {
@@ -146,6 +148,9 @@ class sfException extends Exception
     $response = null;
     if (class_exists('sfContext', false) && sfContext::hasInstance() && is_object($request = sfContext::getInstance()->getRequest()) && is_object($response = sfContext::getInstance()->getResponse()))
     {
+      /** @var $request sfWebRequest */
+      /** @var $response sfWebResponse */
+      
       $dispatcher = sfContext::getInstance()->getEventDispatcher();
 
       if (sfConfig::get('sf_logging_enabled'))

--- a/lib/filter/sfCacheFilter.class.php
+++ b/lib/filter/sfCacheFilter.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -31,7 +31,7 @@ class sfCacheFilter extends sfFilter
    * @param sfContext $context    The current application context
    * @param array     $parameters An associative array of initialization parameters
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this Filter
    */

--- a/lib/filter/sfExecutionFilter.class.php
+++ b/lib/filter/sfExecutionFilter.class.php
@@ -32,6 +32,7 @@ class sfExecutionFilter extends sfFilter
   public function execute($filterChain)
   {
     // get the current action instance
+    /** @var sfAction $actionInstance */
     $actionInstance = $this->context->getController()->getActionStack()->getLastEntry()->getActionInstance();
 
     // execute the action, execute and render the view

--- a/lib/filter/sfFilter.class.php
+++ b/lib/filter/sfFilter.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -20,17 +20,22 @@
  */
 abstract class sfFilter
 {
-  protected
-    $parameterHolder = null,
-    $context         = null;
+  /** @var sfParameterHolder */
+  protected $parameterHolder = null;
+  /** @var sfContext */
+  protected $context = null;
 
+  /** @var bool[] */
   public static
     $filterCalled    = array();
-
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfContext $context
+   * @param array     $parameters
    */
   public function __construct($context, $parameters = array())
   {
@@ -43,7 +48,7 @@ abstract class sfFilter
    * @param sfContext $context    The current application context
    * @param array     $parameters An associative array of initialization parameters
    *
-   * @return boolean true
+   * @return boolean|void true
    */
   public function initialize($context, $parameters = array())
   {

--- a/lib/form/addon/sfFormObject.class.php
+++ b/lib/form/addon/sfFormObject.class.php
@@ -78,9 +78,9 @@ abstract class sfFormObject extends BaseForm
   /**
    * Binds the current form and saves the object to the database in one step.
    *
-   * @param  array An array of tainted values to use to bind the form
-   * @param  array An array of uploaded files (in the $_FILES or $_GET format)
-   * @param  mixed An optional connection object
+   * @param  array $taintedValues An array of tainted values to use to bind the form
+   * @param  array $taintedFiles An array of uploaded files (in the $_FILES or $_GET format)
+   * @param  mixed $con An optional connection object
    *
    * @return Boolean true if the form is valid, false otherwise
    */
@@ -96,8 +96,8 @@ abstract class sfFormObject extends BaseForm
 
     return false;
   }
-
-
+  
+  
   /**
    * Saves the current object to the database.
    *
@@ -107,9 +107,10 @@ abstract class sfFormObject extends BaseForm
    *
    * @return mixed The current saved object
    *
-   * @see doSave()
+   * @throws Exception
+   * @throws sfValidatorErrorSchema
    *
-   * @throws sfValidatorError If the form is not valid
+   * @see doSave()
    */
   public function save($con = null)
   {

--- a/lib/form/addon/sfFormSymfony.class.php
+++ b/lib/form/addon/sfFormSymfony.class.php
@@ -18,6 +18,7 @@
  */
 class sfFormSymfony extends sfForm
 {
+  /** @var sfEventDispatcher|null */
   static protected
     $dispatcher = null;
 
@@ -27,6 +28,7 @@ class sfFormSymfony extends sfForm
    * Notifies the 'form.post_configure' event.
    *
    * @see sfForm
+   * @inheritdoc
    */
   public function __construct($defaults = array(), $options = array(), $CSRFSecret = null)
   {
@@ -62,6 +64,7 @@ class sfFormSymfony extends sfForm
    * Notifies the 'form.filter_values' and 'form.validation_error' events.
    *
    * @see sfForm
+   * @inheritdoc
    */
   protected function doBind(array $values)
   {
@@ -84,7 +87,7 @@ class sfFormSymfony extends sfForm
       throw $error;
     }
   }
-
+  
   /**
    * Calls methods defined via sfEventDispatcher.
    *
@@ -92,6 +95,8 @@ class sfFormSymfony extends sfForm
    * @param array  $arguments The method arguments
    *
    * @return mixed The returned value of the called method
+   *
+   * @throws sfException
    */
   public function __call($method, $arguments)
   {

--- a/lib/form/sfForm.class.php
+++ b/lib/form/sfForm.class.php
@@ -31,23 +31,28 @@ class sfForm implements ArrayAccess, Iterator, Countable
     $CSRFSecret        = false,
     $CSRFFieldName     = '_csrf_token',
     $toStringException = null;
-
-  protected
-    $widgetSchema    = null,
-    $validatorSchema = null,
-    $errorSchema     = null,
-    $formFieldSchema = null,
-    $formFields      = array(),
-    $isBound         = false,
-    $taintedValues   = array(),
-    $taintedFiles    = array(),
-    $values          = null,
-    $defaults        = array(),
-    $fieldNames      = array(),
-    $options         = array(),
-    $count           = 0,
-    $localCSRFSecret = null,
-    $embeddedForms   = array();
+  
+  /** @var sfWidgetFormSchema|sfWidget[]|sfWidgetFormSchemaDecorator[] */
+  protected $widgetSchema    = null;
+  /** @var sfValidatorSchema|sfValidatorBase[] */
+  protected $validatorSchema = null;
+  /** @var sfValidatorErrorSchema|sfValidatorError[] */
+  protected $errorSchema     = null;
+  /** @var sfFormFieldSchema|null */
+  protected $formFieldSchema = null;
+  /** @var sfFormField[] */
+  protected $formFields      = array();
+  protected $isBound         = false;
+  protected $taintedValues   = array();
+  protected $taintedFiles    = array();
+  protected $values          = null;
+  protected $defaults        = array();
+  protected $fieldNames      = array();
+  protected $options         = array();
+  protected $count           = 0;
+  protected $localCSRFSecret = null;
+  /** @var sfForm[] */
+  protected $embeddedForms   = array();
 
   /**
    * Constructor.
@@ -319,7 +324,7 @@ class sfForm implements ArrayAccess, Iterator, Countable
   /**
    * Directly updates embedded form values
    *
-   * @param array $values®
+   * @param array $values
    */
   public function updateValuesEmbeddedForms(array $values)
   {
@@ -788,14 +793,14 @@ class sfForm implements ArrayAccess, Iterator, Countable
 
     return $this;
   }
-
+  
   /**
    * Gets an option value.
    *
    * @param string $name    The option name
    * @param mixed  $default The default value (null by default)
    *
-   * @param mixed  The default value
+   * @return mixed
    */
   public function getOption($name, $default = null)
   {
@@ -824,19 +829,19 @@ class sfForm implements ArrayAccess, Iterator, Countable
    *
    * @param string $name The field name
    *
-   * @param mixed  The default value
+   * @return mixed The default value
    */
   public function getDefault($name)
   {
     return isset($this->defaults[$name]) ? $this->defaults[$name] : null;
   }
-
+  
   /**
    * Returns true if the form has a default value for a form field.
    *
-   * @param string $name The field name
+   * @param string $name   The field name
    *
-   * @param Boolean true if the form has a default value for this field, false otherwise
+   * @return Boolean true if the form has a default value for this field, false otherwise
    */
   public function hasDefault($name)
   {
@@ -1404,10 +1409,12 @@ class sfForm implements ArrayAccess, Iterator, Countable
 
     return $array1;
   }
-
+  
   /**
    * Checks that the $_POST values do not contain something that
    * looks like a file upload (coming from $_FILE).
+   *
+   * @param array $values
    */
   protected function checkTaintedValues($values)
   {

--- a/lib/form/sfFormField.class.php
+++ b/lib/form/sfFormField.class.php
@@ -20,13 +20,17 @@ class sfFormField
 {
   protected static
     $toStringException = null;
-
-  protected
-    $widget = null,
-    $parent = null,
-    $name   = '',
-    $value  = null,
-    $error  = null;
+  
+  /** @var sfWidgetForm */
+  protected $widget = null;
+  /** @var null|sfFormField */
+  protected $parent = null;
+  /** @var string */
+  protected $name = '';
+  /** @var string */
+  protected $value = null;
+  /** @var null|sfValidatorError|sfValidatorErrorSchema */
+  protected $error = null;
 
   /**
    * Constructor.
@@ -235,7 +239,7 @@ class sfFormField
 
   /**
    * Returns the name attribute of the widget.
-   * 
+   *
    * @return string The name attribute of the widget
    */
   public function renderName()
@@ -286,7 +290,7 @@ class sfFormField
   /**
    * Returns the wrapped widget.
    *
-   * @return sfWidget A sfWidget instance
+   * @return sfWidget|sfWidgetFormSchemaDecorator A sfWidget instance
    */
   public function getWidget()
   {

--- a/lib/generator/sfGenerator.class.php
+++ b/lib/generator/sfGenerator.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,17 +18,19 @@
  */
 abstract class sfGenerator
 {
-  protected
-    $generatorClass      = '',
-    $generatorManager    = null,
-    $generatedModuleName = '',
-    $theme               = 'default',
-    $moduleName          = '';
-
+  protected $generatorClass = '';
+  /** @var sfGeneratorManager */
+  protected $generatorManager = null;
+  protected $generatedModuleName = '';
+  protected $theme = 'default';
+  protected $moduleName = '';
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfGeneratorManager $generatorManager
    */
   public function __construct(sfGeneratorManager $generatorManager)
   {
@@ -124,7 +126,7 @@ abstract class sfGenerator
   /**
    * Gets the sfGeneratorManager instance.
    *
-   * @return string The sfGeneratorManager instance
+   * @return sfGeneratorManager The sfGeneratorManager instance
    */
   protected function getGeneratorManager()
   {

--- a/lib/generator/sfGeneratorManager.class.php
+++ b/lib/generator/sfGeneratorManager.class.php
@@ -69,12 +69,16 @@ class sfGeneratorManager
   {
     $this->basePath = $basePath;
   }
-
+  
   /**
    * Saves some content.
    *
    * @param string $path    The relative path
    * @param string $content The content
+   *
+   * @return int
+   *
+   * @throws sfCacheException
    */
   public function save($path, $content)
   {
@@ -109,6 +113,7 @@ class sfGeneratorManager
    */
   public function generate($generatorClass, $param)
   {
+    /** @var sfGenerator $generator */
     $generator = new $generatorClass($this);
 
     return $generator->generate($param);

--- a/lib/generator/sfModelGenerator.class.php
+++ b/lib/generator/sfModelGenerator.class.php
@@ -18,20 +18,22 @@
  */
 abstract class sfModelGenerator extends sfGenerator
 {
-  protected
-    $configuration = null,
-    $primaryKey    = array(),
-    $modelClass    = '',
-    $params        = array(),
-    $config        = array(),
-    $formObject    = null;
-
+  /** @var sfModelGeneratorConfiguration */
+  protected $configuration = null;
+  protected $primaryKey = array();
+  protected $modelClass = '';
+  protected $params = array();
+  protected $config = array();
+  protected $formObject = null;
+  
   /**
    * Generates classes and templates in cache.
    *
    * @param array $params The parameters
    *
    * @return string The data to put in configuration cache
+   *
+   * @throws sfConfigurationException
    */
   public function generate($params = array())
   {
@@ -130,12 +132,11 @@ abstract class sfModelGenerator extends sfGenerator
   {
     return isset($this->params['i18n_catalogue']) ? $this->params['i18n_catalogue'] : 'messages';
   }
-
+  
   /**
    * Returns PHP code for primary keys parameters.
    *
    * @param integer $indent The indentation value
-   * @param string  $callee The function to call
    *
    * @return string The PHP code
    */
@@ -149,11 +150,12 @@ abstract class sfModelGenerator extends sfGenerator
 
     return implode(",\n".str_repeat(' ', max(0, $indent - strlen($this->getSingularName().$this->modelClass))), $params);
   }
-
+  
   /**
    * Returns PHP code to add to a URL for primary keys.
    *
    * @param string $prefix The prefix value
+   * @param bool   $full
    *
    * @return string PHP code
    */
@@ -177,7 +179,7 @@ abstract class sfModelGenerator extends sfGenerator
     return implode(".'&", $params);
   }
 
-  /** 
+  /**
    * Configures this generator.
    */
   abstract protected function configure();
@@ -350,11 +352,14 @@ EOF;
       return $this->getFormObject()->isMultipart() ? ' enctype="multipart/form-data"' : '';
     }
   }
-
+  
   /**
    * Validates the basic structure of the parameters.
    *
    * @param array $params An array of parameters
+   *
+   * @throws sfInitializationException
+   * @throws sfParseException
    */
   protected function validateParameters($params)
   {
@@ -428,9 +433,11 @@ EOF;
 
     return new $class();
   }
-
+  
   /**
    * Returns the URL for a given action.
+   *
+   * @param string $action
    *
    * @return string The URL related to a given action
    */

--- a/lib/generator/sfModelGeneratorConfiguration.class.php
+++ b/lib/generator/sfModelGeneratorConfiguration.class.php
@@ -10,6 +10,7 @@
  */
 abstract class sfModelGeneratorConfiguration
 {
+  /** @var sfModelGeneratorConfigurationField[][][] */
   protected
     $configuration = array();
 
@@ -230,7 +231,12 @@ abstract class sfModelGeneratorConfiguration
       $this->configuration[$context][$key] = str_replace('%%'.$flag.$name.'%%', '%%'.$name.'%%', $this->configuration[$context][$key]);
     }
   }
-
+  
+  /**
+   * @param string        $context
+   * @param string[]|null $fields
+   * @return array|sfModelGeneratorConfigurationField[]
+   */
   public function getContextConfiguration($context, $fields = null)
   {
     if (!isset($this->configuration[$context]))
@@ -293,7 +299,7 @@ abstract class sfModelGeneratorConfiguration
 
     return $escaped ? str_replace("'", "\\'", $v) : $v;
   }
-
+  
   /**
    * Gets the fields that represents the filters.
    *
@@ -301,6 +307,8 @@ abstract class sfModelGeneratorConfiguration
    * all the fields from the form are returned (dynamically).
    *
    * @param sfForm $form The form with the fields
+   *
+   * @return array
    */
   public function getFormFilterFields(sfForm $form)
   {
@@ -341,7 +349,7 @@ abstract class sfModelGeneratorConfiguration
 
     return $fields;
   }
-
+  
   /**
    * Gets the fields that represents the form.
    *
@@ -350,6 +358,8 @@ abstract class sfModelGeneratorConfiguration
    *
    * @param sfForm $form    The form with the fields
    * @param string $context The display context
+   *
+   * @return array
    */
   public function getFormFields(sfForm $form, $context)
   {
@@ -464,6 +474,7 @@ abstract class sfModelGeneratorConfiguration
 
   public function getPager($model)
   {
+    // TODO: Probably `getPagerClass()` method should be abstract here. As well as `getPagerMaxPerPage`
     $class = $this->getPagerClass();
 
     return new $class($model, $this->getPagerMaxPerPage());

--- a/lib/generator/sfModelGeneratorHelper.class.php
+++ b/lib/generator/sfModelGeneratorHelper.class.php
@@ -21,7 +21,12 @@ abstract class sfModelGeneratorHelper
   {
     return '<li class="sf_admin_action_edit">'.link_to(__($params['label'], array(), 'sf_admin'), $this->getUrlForAction('edit'), $object).'</li>';
   }
-
+  
+  /**
+   * @param Persistent|mixed $object
+   * @param array $params
+   * @return string
+   */
   public function linkToDelete($object, $params)
   {
     if ($object->isNew())
@@ -41,7 +46,12 @@ abstract class sfModelGeneratorHelper
   {
     return '<li class="sf_admin_action_save"><input type="submit" value="'.__($params['label'], array(), 'sf_admin').'" /></li>';
   }
-
+  
+  /**
+   * @param Persistent|mixed $object
+   * @param array $params
+   * @return string
+   */
   public function linkToSaveAndAdd($object, $params)
   {
     if (!$object->isNew())

--- a/lib/log/sfAggregateLogger.class.php
+++ b/lib/log/sfAggregateLogger.class.php
@@ -76,7 +76,7 @@ class sfAggregateLogger extends sfLogger
   /**
    * Adds a logger.
    *
-   * @param object $logger The Logger object
+   * @param sfLoggerInterface $logger The Logger object
    */
   public function addLogger(sfLoggerInterface $logger)
   {

--- a/lib/log/sfAggregateLogger.class.php
+++ b/lib/log/sfAggregateLogger.class.php
@@ -31,7 +31,7 @@ class sfAggregateLogger extends sfLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean      true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -47,7 +47,7 @@ class sfAggregateLogger extends sfLogger
       $this->addLoggers($options['loggers']);
     }
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 
   /**

--- a/lib/log/sfAggregateLogger.class.php
+++ b/lib/log/sfAggregateLogger.class.php
@@ -89,7 +89,7 @@ class sfAggregateLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfConsoleLogger.class.php
+++ b/lib/log/sfConsoleLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -20,11 +20,16 @@ class sfConsoleLogger extends sfStreamLogger
 {
   /**
    * @see sfStreamLogger
+   *
+   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param  array             $options     An array of options.
+   *
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
     $options['stream'] = defined('STDOUT') ? STDOUT : fopen('php://stdout', 'w');
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 }

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -23,7 +23,7 @@ class sfFileLogger extends sfLogger
     $format     = '%time% %type% [%priority%] %message%%EOL%',
     $timeFormat = '%b %d %H:%M:%S',
     $fp         = null;
-
+  
   /**
    * Initializes this logger.
    *
@@ -40,6 +40,9 @@ class sfFileLogger extends sfLogger
    * @param  array             $options     An array of options.
    *
    * @return void
+   *
+   * @throws sfConfigurationException
+   * @throws sfFileException
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -92,7 +92,7 @@ class sfFileLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfFileLogger.class.php
+++ b/lib/log/sfFileLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -39,7 +39,7 @@ class sfFileLogger extends sfLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean      true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -82,7 +82,7 @@ class sfFileLogger extends sfLogger
       chmod($options['file'], isset($options['file_mode']) ? $options['file_mode'] : 0666);
     }
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 
   /**

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -129,12 +129,13 @@ abstract class sfLogger implements sfLoggerInterface
 
     $this->level = $level;
   }
-
+  
   /**
    * Logs a message.
    *
    * @param string $message   Message
    * @param string $priority  Message priority
+   * @return void|bool
    */
   public function log($message, $priority = self::INFO)
   {
@@ -143,7 +144,7 @@ abstract class sfLogger implements sfLoggerInterface
       return false;
     }
 
-    return $this->doLog($message, $priority);
+    $this->doLog($message, $priority);
   }
 
   /**

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -91,6 +91,8 @@ abstract class sfLogger implements sfLoggerInterface
   
   /**
    * Returns the options for the logger instance.
+   *
+   * @return array
    */
   public function getOptions()
   {
@@ -99,6 +101,9 @@ abstract class sfLogger implements sfLoggerInterface
   
   /**
    * Returns the options for the logger instance.
+   *
+   * @param string $name
+   * @param mixed $value
    */
   public function setOption($name, $value)
   {
@@ -108,7 +113,7 @@ abstract class sfLogger implements sfLoggerInterface
   /**
    * Retrieves the log level for the current logger instance.
    *
-   * @return string Log level
+   * @return int Log level
    */
   public function getLogLevel()
   {
@@ -118,7 +123,7 @@ abstract class sfLogger implements sfLoggerInterface
   /**
    * Sets a log level for the current logger instance.
    *
-   * @param string $level Log level
+   * @param int $level Log level
    */
   public function setLogLevel($level)
   {
@@ -134,7 +139,7 @@ abstract class sfLogger implements sfLoggerInterface
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    * @return void|bool
    */
   public function log($message, $priority = self::INFO)
@@ -151,7 +156,7 @@ abstract class sfLogger implements sfLoggerInterface
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   abstract protected function doLog($message, $priority);
 

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -46,6 +46,9 @@ abstract class sfLogger implements sfLoggerInterface
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
+   * @param  array             $options     An array of options.
    */
   public function __construct(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -67,7 +70,7 @@ abstract class sfLogger implements sfLoggerInterface
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean      true, if initialization completes successfully, otherwise false.
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfLogger.
    */

--- a/lib/log/sfLogger.class.php
+++ b/lib/log/sfLogger.class.php
@@ -36,11 +36,13 @@ abstract class sfLogger implements sfLoggerInterface
   const NOTICE  = 5; // Normal but significant
   const INFO    = 6; // Informational
   const DEBUG   = 7; // Debug-level messages
-
-  protected
-    $dispatcher = null,
-    $options = array(),
-    $level = self::INFO;
+  
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var array */
+  protected $options = array();
+  /** @var int */
+  protected $level = self::INFO;
 
   /**
    * Class constructor.

--- a/lib/log/sfLoggerInterface.class.php
+++ b/lib/log/sfLoggerInterface.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -22,7 +22,7 @@ interface sfLoggerInterface
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   public function log($message, $priority = null);
 }

--- a/lib/log/sfLoggerWrapper.class.php
+++ b/lib/log/sfLoggerWrapper.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -18,6 +18,7 @@
  */
 class sfLoggerWrapper extends sfLogger
 {
+  /** @var sfLoggerInterface */
   protected
     $logger = null;
 

--- a/lib/log/sfLoggerWrapper.class.php
+++ b/lib/log/sfLoggerWrapper.class.php
@@ -36,7 +36,7 @@ class sfLoggerWrapper extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfNoLogger.class.php
+++ b/lib/log/sfNoLogger.class.php
@@ -34,7 +34,7 @@ class sfNoLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfNoLogger.class.php
+++ b/lib/log/sfNoLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -24,7 +24,7 @@ class sfNoLogger extends sfLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean      true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {

--- a/lib/log/sfPsrLoggerAdapter.class.php
+++ b/lib/log/sfPsrLoggerAdapter.class.php
@@ -118,7 +118,7 @@ class sfPsrLoggerAdapter extends sfLogger
    * Logs a message.
    *
    * @param string $message Message
-   * @param string $priority Message priority
+   * @param int    $priority Message priority
    *
    * @return void
    */

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -69,7 +69,7 @@ class sfStreamLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -29,10 +29,12 @@ class sfStreamLogger extends sfLogger
    *
    * - stream: A PHP stream
    *
-   * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
-   * @param  array             $options     An array of options.
+   * @param  sfEventDispatcher $dispatcher A sfEventDispatcher instance
+   * @param  array             $options    An array of options.
    *
    * @return void
+   *
+   * @throws sfConfigurationException
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -56,7 +58,7 @@ class sfStreamLogger extends sfLogger
   /**
    * Sets the PHP stream to use for this logger.
    *
-   * @param stream $stream A php stream
+   * @param resource $stream A php stream
    */
   public function setStream($stream)
   {

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -31,7 +31,7 @@ class sfStreamLogger extends sfLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean      true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -49,7 +49,7 @@ class sfStreamLogger extends sfLogger
 
     $this->stream = $options['stream'];
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 
   /**

--- a/lib/log/sfStreamLogger.class.php
+++ b/lib/log/sfStreamLogger.class.php
@@ -18,6 +18,7 @@
  */
 class sfStreamLogger extends sfLogger
 {
+  /** @var resource */
   protected
     $stream = null;
 

--- a/lib/log/sfVarLogger.class.php
+++ b/lib/log/sfVarLogger.class.php
@@ -130,7 +130,7 @@ class sfVarLogger extends sfLogger
    * Logs a message.
    *
    * @param string $message   Message
-   * @param string $priority  Message priority
+   * @param int    $priority  Message priority
    */
   protected function doLog($message, $priority)
   {

--- a/lib/log/sfVarLogger.class.php
+++ b/lib/log/sfVarLogger.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -32,7 +32,7 @@ class sfVarLogger extends sfLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean           true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -44,7 +44,7 @@ class sfVarLogger extends sfLogger
       $this->xdebugLogging = false;
     }
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 
   /**
@@ -53,7 +53,7 @@ class sfVarLogger extends sfLogger
    * Each log entry has the following attributes:
    *
    *  * priority
-   *  * time   
+   *  * time
    *  * message
    *  * type
    *  * debugStack
@@ -156,7 +156,7 @@ class sfVarLogger extends sfLogger
    * Returns the debug stack.
    *
    * @return array
-   * 
+   *
    * @see debug_backtrace()
    */
   protected function getDebugBacktrace()

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -18,10 +18,12 @@
  */
 class sfWebDebugLogger extends sfVarLogger
 {
-  protected
-    $context       = null,
-    $webDebugClass = null,
-    $webDebug      = null;
+  /** @var sfContext */
+  protected $context       = null;
+  /** @var string */
+  protected $webDebugClass = null;
+  /** @var sfWebDebug */
+  protected $webDebug      = null;
 
   /**
    * Initializes this logger.
@@ -147,6 +149,7 @@ class sfWebDebugLogger extends sfVarLogger
     // * if not rendering to the client
     // * if HTTP headers only
     $response = $event->getSubject();
+    /** @var sfWebRequest $request */
     $request  = $this->context->getRequest();
     if (
       null === $this->webDebug

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -33,7 +33,7 @@ class sfWebDebugLogger extends sfVarLogger
    * @param  sfEventDispatcher $dispatcher  A sfEventDispatcher instance
    * @param  array             $options     An array of options.
    *
-   * @return Boolean           true, if initialization completes successfully, otherwise false.
+   * @return void
    *
    * @see sfVarLogger
    */
@@ -51,7 +51,7 @@ class sfWebDebugLogger extends sfVarLogger
 
     $this->registerErrorHandler();
 
-    return parent::initialize($dispatcher, $options);
+    parent::initialize($dispatcher, $options);
   }
 
   /**
@@ -104,7 +104,7 @@ class sfWebDebugLogger extends sfVarLogger
 
   /**
    * Listens for the context.load_factories event.
-   * 
+   *
    * @param sfEvent $event
    */
   public function listenForLoadFactories(sfEvent $event)

--- a/lib/log/sfWebDebugLogger.class.php
+++ b/lib/log/sfWebDebugLogger.class.php
@@ -63,7 +63,7 @@ class sfWebDebugLogger extends sfVarLogger
   {
     set_error_handler(array($this,'handlePhpError'));
   }
-
+  
   /**
    * PHP error handler send PHP errors to log.
    *
@@ -76,6 +76,8 @@ class sfWebDebugLogger extends sfVarLogger
    * @param string $errfile    The filename that the error was raised in, as a string.
    * @param string $errline    The line number the error was raised at, as an integer.
    * @param array  $errcontext An array that points to the active symbol table at the point the error occurred.
+   *
+   * @return bool
    */
   public function handlePhpError($errno, $errstr, $errfile, $errline, $errcontext = array())
   {

--- a/lib/request/sfRequest.class.php
+++ b/lib/request/sfRequest.class.php
@@ -29,19 +29,28 @@ abstract class sfRequest implements ArrayAccess
   const DELETE = 'DELETE';
   const HEAD   = 'HEAD';
   const OPTIONS = 'OPTIONS';
-
-  protected
-    $dispatcher      = null,
-    $content         = null,
-    $method          = null,
-    $options         = array(),
-    $parameterHolder = null,
-    $attributeHolder = null;
-
+  
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var string|null */
+  protected $content = null;
+  /** @var string */
+  protected $method = null;
+  protected $options = array();
+  /** @var sfParameterHolder */
+  protected $parameterHolder = null;
+  /** @var sfParameterHolder */
+  protected $attributeHolder = null;
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfEventDispatcher $dispatcher
+   * @param array             $parameters
+   * @param array             $attributes
+   * @param array             $options
    */
   public function __construct(sfEventDispatcher $dispatcher, $parameters = array(), $attributes = array(), $options = array())
   {
@@ -60,7 +69,7 @@ abstract class sfRequest implements ArrayAccess
    * @param  array             $attributes  An associative array of initialization attributes
    * @param  array             $options     An associative array of options
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfRequest
    */
@@ -258,13 +267,14 @@ abstract class sfRequest implements ArrayAccess
   {
     $this->attributeHolder->set($name, $value);
   }
-
+  
   /**
    * Retrieves a parameter for the current request.
    *
-   * @param string $name     Parameter name
-   * @param string $default  Parameter default value
+   * @param string $name    Parameter name
+   * @param string $default Parameter default value
    *
+   * @return mixed
    */
   public function getParameter($name, $default = null)
   {

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -56,7 +56,7 @@ class sfWebRequest extends sfRequest
    * @param  array             $attributes  An associative array of initialization attributes
    * @param  array             $options     An associative array of options
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfRequest
    *
@@ -169,7 +169,7 @@ class sfWebRequest extends sfRequest
   /**
    * Returns the content type of the current request.
    *
-   * @param  Boolean $trimmed If false the full Content-Type header will be returned
+   * @param  Boolean $trim If false the full Content-Type header will be returned
    *
    * @return string
    */
@@ -568,7 +568,7 @@ class sfWebRequest extends sfRequest
   /**
    * Gets the value of HTTP header
    *
-   * @param string $nameThe HTTP header name
+   * @param string $name The HTTP header name
    * @param string $prefix The HTTP header prefix
    * @return string The value of HTTP header
    */
@@ -663,11 +663,13 @@ class sfWebRequest extends sfRequest
   {
     $this->relativeUrlRoot = $value;
   }
-
+  
   /**
    * Splits an HTTP header for the current web request.
    *
-   * @param string $header  Header to split
+   * @param string $header Header to split
+   *
+   * @return array
    */
   public function splitHttpAcceptHeader($header)
   {

--- a/lib/response/sfResponse.class.php
+++ b/lib/response/sfResponse.class.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -19,15 +19,18 @@
  */
 abstract class sfResponse implements Serializable
 {
-  protected
-    $options    = array(),
-    $dispatcher = null,
-    $content    = '';
-
+  protected $options = array();
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  protected $content = '';
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfEventDispatcher $dispatcher
+   * @param array             $options
    */
   public function __construct(sfEventDispatcher $dispatcher, $options = array())
   {
@@ -44,7 +47,7 @@ abstract class sfResponse implements Serializable
    * @param  sfEventDispatcher  $dispatcher  An sfEventDispatcher instance
    * @param  array              $options     An array of options
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfResponse
    */

--- a/lib/response/sfWebResponse.class.php
+++ b/lib/response/sfWebResponse.class.php
@@ -97,7 +97,7 @@ class sfWebResponse extends sfResponse
    * @param  sfEventDispatcher $dispatcher  An sfEventDispatcher instance
    * @param  array             $options     An array of options
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfResponse
    *
@@ -680,7 +680,7 @@ class sfWebResponse extends sfResponse
    *
    * @param string $file      The stylesheet file
    * @param string $position  Position
-   * @param string $options   Stylesheet options
+   * @param array  $options   Stylesheet options
    */
   public function addStylesheet($file, $position = '', $options = array())
   {
@@ -753,7 +753,7 @@ class sfWebResponse extends sfResponse
    *
    * @param string $file      The JavaScript file
    * @param string $position  Position
-   * @param string $options   Javascript options
+   * @param array  $options   Javascript options
    */
   public function addJavascript($file, $position = '', $options = array())
   {
@@ -881,6 +881,7 @@ class sfWebResponse extends sfResponse
 
   /**
    * @see sfResponse
+   * @inheritdoc
    */
   public function unserialize($serialized)
   {

--- a/lib/routing/sfObjectRoute.class.php
+++ b/lib/routing/sfObjectRoute.class.php
@@ -20,9 +20,10 @@
  */
 class sfObjectRoute extends sfRequestRoute
 {
-  protected
-    $object  = false,
-    $objects = false;
+  /** @var bool|object */
+  protected $object = false;
+  /** @var bool|array */
+  protected $objects = false;
 
   /**
    * Constructor.
@@ -80,13 +81,15 @@ class sfObjectRoute extends sfRequestRoute
   {
     return parent::generate('object' == $this->options['type'] ? $this->convertObjectToArray($params) : $params, $context, $absolute);
   }
-
+  
   /**
    * Gets the object related to the current route and parameters.
    *
    * This method is only accessible if the route is bound and of type "object".
    *
    * @return Object The related object
+   *
+   * @throws sfError404Exception
    */
   public function getObject()
   {
@@ -113,13 +116,15 @@ class sfObjectRoute extends sfRequestRoute
 
     return $this->object;
   }
-
+  
   /**
    * Gets the list of objects related to the current route and parameters.
    *
    * This method is only accessible if the route is bound and of type "list".
    *
    * @return array And array of related objects
+   *
+   * @throws sfError404Exception
    */
   public function getObjects()
   {

--- a/lib/routing/sfPatternRouting.class.php
+++ b/lib/routing/sfPatternRouting.class.php
@@ -20,12 +20,13 @@
  */
 class sfPatternRouting extends sfRouting
 {
-  protected
-    $currentRouteName   = null,
-    $currentInternalUri = array(),
-    $routes             = array(),
-    $cacheData          = array(),
-    $cacheChanged       = false;
+  /** @var null|string */
+  protected $currentRouteName = null;
+  protected $currentInternalUri = array();
+  /** @var sfRoute[] */
+  protected $routes = array();
+  protected $cacheData = array();
+  protected $cacheChanged = false;
 
   /**
    * Initializes this Routing.
@@ -43,6 +44,7 @@ class sfPatternRouting extends sfRouting
    *                                      cache backend (like sfAPCCache).
    *
    * @see sfRouting
+   * @inheritdoc
    */
   public function initialize(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array())
   {
@@ -73,6 +75,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function loadConfiguration()
   {
@@ -86,6 +89,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function setDefaultParameter($key, $value)
   {
@@ -102,6 +106,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function setDefaultParameters($parameters)
   {
@@ -120,9 +125,10 @@ class sfPatternRouting extends sfRouting
   {
     return sfContext::getInstance()->getConfigCache()->checkConfig('config/routing.yml', true);
   }
-
+  
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function getCurrentInternalUri($withRouteName = false)
   {
@@ -141,6 +147,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function getRoutes()
   {
@@ -149,6 +156,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see  sfRouting
+   * @inheritdoc
    */
   public function getRoute($name)
   {
@@ -170,6 +178,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function setRoutes($routes)
   {
@@ -181,6 +190,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function hasRoutes()
   {
@@ -189,6 +199,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function clearRoutes()
   {
@@ -211,11 +222,14 @@ class sfPatternRouting extends sfRouting
   {
     return array_key_exists($name, $this->routes);
   }
-
+  
   /**
    * Adds a new route at the beginning of the current list of routes.
    *
    * @see connect
+   *
+   * @param string $name
+   * @param sfRoute $route
    */
   public function prependRoute($name, $route)
   {
@@ -224,23 +238,33 @@ class sfPatternRouting extends sfRouting
     $this->connect($name, $route);
     $this->routes = array_merge($this->routes, $routes);
   }
-
+  
   /**
    * Adds a new route.
    *
    * Alias for the connect method.
    *
    * @see connect
+   *
+   * @param string $name
+   * @param sfRoute $route
+   * @return array
    */
   public function appendRoute($name, $route)
   {
     return $this->connect($name, $route);
   }
-
+  
   /**
    * Adds a new route before a given one in the current list of routes.
    *
    * @see connect
+   *
+   * @param string $pivot
+   * @param string $name
+   * @param sfRoute $route
+   *
+   * @throws sfConfigurationException
    */
   public function insertRouteBefore($pivot, $name, $route)
   {
@@ -306,6 +330,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function generate($name, $params = array(), $absolute = false)
   {
@@ -362,6 +387,7 @@ class sfPatternRouting extends sfRouting
 
   /**
    * @see sfRouting
+   * @inheritdoc
    */
   public function parse($url)
   {

--- a/lib/routing/sfRequestRoute.class.php
+++ b/lib/routing/sfRequestRoute.class.php
@@ -47,7 +47,7 @@ class sfRequestRoute extends sfRoute
    * @param  string  $url     The URL
    * @param  array   $context The context
    *
-   * @return array   An array of parameters
+   * @return array|bool   An array of parameters or false if not matching
    */
   public function matchesUrl($url, $context = array())
   {

--- a/lib/routing/sfRoute.class.php
+++ b/lib/routing/sfRoute.class.php
@@ -15,6 +15,9 @@
  * @subpackage routing
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
+ *
+ * @property $firstOptional int
+ * @property $segments array
  */
 class sfRoute implements Serializable
 {
@@ -89,7 +92,7 @@ class sfRoute implements Serializable
    * @param  string  $url     The URL
    * @param  array   $context The context
    *
-   * @return array   An array of parameters
+   * @return array|bool   An array of parameters or false if not matching
    */
   public function matchesUrl($url, $context = array())
   {
@@ -263,11 +266,13 @@ class sfRoute implements Serializable
   {
     return strlen($a) < strlen($b);
   }
-
+  
   /**
    * Generates a URL for the given parameters by using the route tokens.
    *
    * @param array $parameters An array of parameters
+   *
+   * @return string
    */
   protected function generateWithTokens($parameters)
   {

--- a/lib/routing/sfRouting.class.php
+++ b/lib/routing/sfRouting.class.php
@@ -18,16 +18,21 @@
  */
 abstract class sfRouting
 {
-  protected
-    $dispatcher        = null,
-    $cache             = null,
-    $defaultParameters = array(),
-    $options           = array();
-
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var sfCache|null */
+  protected $cache = null;
+  protected $defaultParameters = array();
+  protected $options = array();
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfEventDispatcher $dispatcher
+   * @param sfCache           $cache
+   * @param array             $options
    */
   public function __construct(sfEventDispatcher $dispatcher, sfCache $cache = null, $options = array())
   {
@@ -237,13 +242,14 @@ abstract class sfRouting
     // change the culture in the routing default parameters
     $this->setDefaultParameter('sf_culture', $event['culture']);
   }
-
+  
   /**
    * Listens to the request.filter_parameters event.
    *
-   * @param  sfEvent $event       An sfEvent instance
+   * @param  sfEvent $event An sfEvent instance
+   * @param  array   $parameters
    *
-   * @return array   $parameters  An array of parameters for the event
+   * @return array $parameters  An array of parameters for the event
    */
   public function filterParametersEvent(sfEvent $event, $parameters)
   {

--- a/lib/service/sfServiceContainerBuilder.class.php
+++ b/lib/service/sfServiceContainerBuilder.class.php
@@ -175,12 +175,14 @@ class sfServiceContainerBuilder extends sfServiceContainer
   {
     return $this->definitions;
   }
-
+  
   /**
    * Sets a service definition.
    *
    * @param  string              $id         The service identifier
    * @param  sfServiceDefinition $definition A sfServiceDefinition instance
+   *
+   * @return sfServiceDefinition
    */
   public function setServiceDefinition($id, sfServiceDefinition $definition)
   {

--- a/lib/service/sfServiceContainerDumperPhp.class.php
+++ b/lib/service/sfServiceContainerDumperPhp.class.php
@@ -45,7 +45,12 @@ class sfServiceContainerDumperPhp extends sfServiceContainerDumper
       $this->endClass()
     ;
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceInclude($id, $definition)
   {
     if (null !== $definition->getFile())
@@ -53,7 +58,12 @@ class sfServiceContainerDumperPhp extends sfServiceContainerDumper
       return sprintf("    require_once %s;\n\n", $this->dumpValue($definition->getFile()));
     }
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceShared($id, $definition)
   {
     if ($definition->isShared())
@@ -65,7 +75,12 @@ class sfServiceContainerDumperPhp extends sfServiceContainerDumper
 EOF;
     }
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceReturn($id, $definition)
   {
     if ($definition->isShared())
@@ -87,7 +102,12 @@ EOF;
 EOF;
     }
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceInstance($id, $definition)
   {
     $class = $this->dumpValue($definition->getClass());
@@ -114,7 +134,12 @@ EOF;
       }
     }
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceMethodCalls($id, $definition)
   {
     $calls = '';
@@ -131,7 +156,12 @@ EOF;
 
     return $calls;
   }
-
+  
+  /**
+   * @param string $id
+   * @param sfServiceDefinition $definition
+   * @return string
+   */
   protected function addServiceConfigurator($id, $definition)
   {
     if (!$callable = $definition->getConfigurator())

--- a/lib/storage/sfCacheSessionStorage.class.php
+++ b/lib/storage/sfCacheSessionStorage.class.php
@@ -12,15 +12,20 @@
  */
 class sfCacheSessionStorage extends sfStorage
 {
-  protected
-    $id          = null,
-    $context     = null,
-    $dispatcher  = null,
-    $request     = null,
-    $response    = null,
-    $cache       = null,
-    $data        = array(),
-    $dataChanged = false;
+  /** @var string */
+  protected $id = null;
+  /** @var sfContext */
+  protected $context = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var sfWebRequest */
+  protected $request = null;
+  /** @var sfWebResponse */
+  protected $response = null;
+  /** @var sfCache|null */
+  protected $cache = null;
+  protected $data = array();
+  protected $dataChanged = false;
 
   /**
    * Initialize this Storage.

--- a/lib/storage/sfDatabaseSessionStorage.class.php
+++ b/lib/storage/sfDatabaseSessionStorage.class.php
@@ -20,10 +20,11 @@
  */
 abstract class sfDatabaseSessionStorage extends sfSessionStorage
 {
-  protected
-    $db = null,
-    $con = null;
-
+  /** @var sfDatabase */
+  protected $db = null;
+  /** @var PDO */
+  protected $con = null;
+  
   /**
    * Available options:
    *
@@ -33,7 +34,10 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    *   * db_data_col: The database column in which the session data will be stored (sess_data by default)
    *   * db_time_col: The database column in which the session timestamp will be stored (sess_time by default)
    *
-   * @param  array $options  An associative array of options
+   * @param  array $options An associative array of options
+   * @return bool|void
+   *
+   * @throws sfInitializationException
    *
    * @see sfSessionStorage
    */
@@ -97,6 +101,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
   public function sessionOpen($path = null, $name = null)
   {
     // what database are we using?
+    /** @var sfDatabase $database */
     $database = $this->options['database'];
 
     // get the database and connection
@@ -174,7 +179,7 @@ abstract class sfDatabaseSessionStorage extends sfSessionStorage
    *
    * @param  boolean $destroy Destroy session when regenerating?
    *
-   * @return boolean True if session regenerated, false if error
+   * @return boolean|void True if session regenerated, false if error
    *
    */
   public function regenerate($destroy = false)

--- a/lib/storage/sfSessionStorage.class.php
+++ b/lib/storage/sfSessionStorage.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -28,7 +28,7 @@ class sfSessionStorage extends sfStorage
   static protected
     $sessionIdRegenerated = false,
     $sessionStarted       = false;
-
+  
   /**
    * Available options:
    *
@@ -43,9 +43,11 @@ class sfSessionStorage extends sfStorage
    *
    * The default values for all 'session_cookie_*' options are those returned by the session_get_cookie_params() function
    *
-   * @param array $options  An associative array of options
+   * @param array $options An associative array of options
    *
    * @see sfStorage
+   *
+   * @return void
    */
   public function initialize($options = null)
   {
@@ -157,7 +159,7 @@ class sfSessionStorage extends sfStorage
    *
    * @param  boolean $destroy Destroy session when regenerating?
    *
-   * @return boolean True if session regenerated, false if error
+   * @return bool|void
    *
    */
   public function regenerate($destroy = false)

--- a/lib/storage/sfStorage.class.php
+++ b/lib/storage/sfStorage.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -22,11 +22,13 @@ abstract class sfStorage
 {
   protected
     $options = array();
-
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param array $options
    */
   public function __construct($options = array())
   {
@@ -47,7 +49,7 @@ abstract class sfStorage
    *
    * @param  array $options  An associative array of options
    *
-   * @return bool true, if initialization completes successfully, otherwise false
+   * @return void
    *
    * @throws <b>sfInitializationException</b> If an error occurs while initializing this sfStorage
    */

--- a/lib/task/sfBaseTask.class.php
+++ b/lib/task/sfBaseTask.class.php
@@ -25,6 +25,7 @@ abstract class sfBaseTask extends sfCommandApplicationTask
 
   /**
    * @see sfTask
+   * @inheritdoc
    */
   protected function doRun(sfCommandManager $commandManager, $options)
   {
@@ -104,11 +105,13 @@ abstract class sfBaseTask extends sfCommandApplicationTask
 
     return $this->filesystem;
   }
-
+  
   /**
    * Checks if the current directory is a symfony project directory.
    *
    * @return true if the current directory is a symfony project directory, false otherwise
+   *
+   * @throws sfException
    */
   public function checkProjectExists()
   {
@@ -117,13 +120,15 @@ abstract class sfBaseTask extends sfCommandApplicationTask
       throw new sfException('You must be in a symfony project directory.');
     }
   }
-
+  
   /**
    * Checks if an application exists.
    *
-   * @param  string $app  The application name
+   * @param  string $app The application name
    *
    * @return bool true if the application exists, false otherwise
+   *
+   * @throws sfException
    */
   public function checkAppExists($app)
   {
@@ -132,14 +137,16 @@ abstract class sfBaseTask extends sfCommandApplicationTask
       throw new sfException(sprintf('Application "%s" does not exist', $app));
     }
   }
-
+  
   /**
    * Checks if a module exists.
    *
-   * @param  string $app     The application name
-   * @param  string $module  The module name
+   * @param  string $app    The application name
+   * @param  string $module The module name
    *
    * @return bool true if the module exists, false otherwise
+   *
+   * @throws sfException
    */
   public function checkModuleExists($app, $module)
   {

--- a/lib/task/sfCommandApplicationTask.class.php
+++ b/lib/task/sfCommandApplicationTask.class.php
@@ -15,17 +15,21 @@
  * @subpackage task
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id$
+ *
+ * @property sfApplicationConfiguration $configuration
  */
 abstract class sfCommandApplicationTask extends sfTask
 {
-  protected
-    $commandApplication;
-
-  private
-    $mailer,
-    $routing,
-    $serviceContainer,
-    $factoryConfiguration;
+  /** @var sfSymfonyCommandApplication */
+  protected $commandApplication;
+  
+  /** @var sfMailer */
+  private $mailer;
+  /** @var sfRouting */
+  private $routing;
+  /** @var sfServiceContainer */
+  private $serviceContainer;
+  private $factoryConfiguration;
 
   /**
    * Sets the command application instance for this task.
@@ -39,6 +43,7 @@ abstract class sfCommandApplicationTask extends sfTask
 
   /**
    * @see sfTask
+   * @inheritdoc
    */
   public function log($messages)
   {
@@ -50,6 +55,7 @@ abstract class sfCommandApplicationTask extends sfTask
 
   /**
    * @see sfTask
+   * @inheritdoc
    */
   public function logSection($section, $message, $size = null, $style = 'INFO')
   {
@@ -172,6 +178,7 @@ abstract class sfCommandApplicationTask extends sfTask
     $handler = new sfRoutingConfigHandler();
     $routes = $handler->evaluate($this->configuration->getConfigPaths('config/routing.yml'));
 
+    /** @var sfRouting $routing */
     $routing = new $config['routing']['class']($this->dispatcher, null, $params);
     $routing->setRoutes($routes);
 

--- a/lib/task/sfFilesystem.class.php
+++ b/lib/task/sfFilesystem.class.php
@@ -33,7 +33,7 @@ class sfFilesystem
     $this->dispatcher = $dispatcher;
     $this->formatter = $formatter;
   }
-
+  
   /**
    * Copies a file.
    *
@@ -46,6 +46,8 @@ class sfFilesystem
    * @param string $originFile  The original filename
    * @param string $targetFile  The target filename
    * @param array  $options     An array of options
+   *
+   * @return bool
    */
   public function copy($originFile, $targetFile, $options = array())
   {
@@ -173,12 +175,16 @@ class sfFilesystem
 
     umask($currentUmask);
   }
-
+  
   /**
    * Renames a file.
    *
    * @param string $origin  The origin filename
    * @param string $target  The new filename
+   *
+   * @return bool
+   *
+   * @throws sfException
    */
   public function rename($origin, $target)
   {
@@ -245,7 +251,7 @@ class sfFilesystem
 
     $this->symlink($originDir, $targetDir, $copyOnWindows);
   }
-
+  
   /**
    * Mirrors a directory to another.
    *
@@ -253,6 +259,8 @@ class sfFilesystem
    * @param string   $targetDir  The target directory
    * @param sfFinder $finder     An sfFinder instance
    * @param array    $options    An array of options (see copy())
+   *
+   * @throws sfException
    */
   public function mirror($originDir, $targetDir, $finder, $options = array())
   {
@@ -453,7 +461,7 @@ class sfFilesystem
   }
 
   /**
-   * @param string A filesystem path
+   * @param string $path A filesystem path
    *
    * @return string
    */

--- a/lib/task/sfTask.class.php
+++ b/lib/task/sfTask.class.php
@@ -18,16 +18,17 @@
  */
 abstract class sfTask
 {
-  protected
-    $namespace           = '',
-    $name                = null,
-    $aliases             = array(),
-    $briefDescription    = '',
-    $detailedDescription = '',
-    $arguments           = array(),
-    $options             = array(),
-    $dispatcher          = null,
-    $formatter           = null;
+  protected $namespace = '';
+  protected $name = null;
+  protected $aliases = array();
+  protected $briefDescription = '';
+  protected $detailedDescription = '';
+  protected $arguments = array();
+  protected $options = array();
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  /** @var sfFormatter */
+  protected $formatter = null;
 
   /**
    * Constructor.
@@ -74,7 +75,7 @@ abstract class sfTask
   /**
    * Sets the formatter instance.
    *
-   * @param sfFormatter The formatter instance
+   * @param sfFormatter $formatter The formatter instance
    */
   public function setFormatter(sfFormatter $formatter)
   {
@@ -176,7 +177,7 @@ abstract class sfTask
   /**
    * Returns the argument objects.
    *
-   * @return sfCommandArgument An array of sfCommandArgument objects.
+   * @return sfCommandArgument[] An array of sfCommandArgument objects.
    */
   public function getArguments()
   {
@@ -186,19 +187,23 @@ abstract class sfTask
   /**
    * Adds an array of argument objects.
    *
-   * @param array $arguments  An array of arguments
+   * @param sfCommandArgument[] $arguments  An array of arguments
    */
   public function addArguments($arguments)
   {
     $this->arguments = array_merge($this->arguments, $arguments);
   }
-
+  
   /**
    * Add an argument.
    *
    * This method always use the sfCommandArgument class to create an option.
    *
    * @see sfCommandArgument::__construct()
+   * @param string $name
+   * @param int    $mode
+   * @param string $help
+   * @param mixed  $default
    */
   public function addArgument($name, $mode = null, $help = '', $default = null)
   {
@@ -208,7 +213,7 @@ abstract class sfTask
   /**
    * Returns the options objects.
    *
-   * @return sfCommandOption An array of sfCommandOption objects.
+   * @return sfCommandOption[] An array of sfCommandOption objects.
    */
   public function getOptions()
   {
@@ -224,13 +229,19 @@ abstract class sfTask
   {
     $this->options = array_merge($this->options, $options);
   }
-
+  
   /**
    * Add an option.
    *
    * This method always use the sfCommandOption class to create an option.
    *
    * @see sfCommandOption::__construct()
+   *
+   * @param string $name
+   * @param string $shortcut
+   * @param int    $mode
+   * @param string $help
+   * @param mixed  $default
    */
   public function addOption($name, $shortcut = null, $mode = null, $help = '', $default = null)
   {
@@ -453,7 +464,7 @@ abstract class sfTask
    * @param string       $style    The style to use (QUESTION by default)
    * @param string       $default  The default answer if none is given by the user
    *
-   * @param string       The user answer
+   * @return string      The user answer
    */
   public function ask($question, $style = 'QUESTION', $default = null)
   {
@@ -480,7 +491,7 @@ abstract class sfTask
    * @param string       $style    The style to use (QUESTION by default)
    * @param Boolean      $default  The default answer if the user enters nothing
    *
-   * @param Boolean      true if the user has confirmed, false otherwise
+   * @return Boolean     true if the user has confirmed, false otherwise
    */
   public function askConfirmation($question, $style = 'QUESTION', $default = true)
   {
@@ -499,7 +510,7 @@ abstract class sfTask
       return !$answer || 'y' == strtolower($answer[0]);
     }
   }
-
+  
   /**
    * Asks for a value and validates the response.
    *
@@ -513,7 +524,9 @@ abstract class sfTask
    * @param   sfValidatorBase $validator
    * @param   array           $options
    *
-   * @return  mixed
+   * @return mixed
+   *
+   * @throws sfValidatorError
    */
   public function askAndValidate($question, sfValidatorBase $validator, array $options = array())
   {
@@ -541,6 +554,7 @@ abstract class sfTask
     }
 
     // no, ask the user for a valid user
+    /** @var sfValidatorError|null $error */
     $error = null;
     while (false === $options['attempts'] || $options['attempts']--)
     {

--- a/lib/user/sfUser.class.php
+++ b/lib/user/sfUser.class.php
@@ -30,18 +30,24 @@ class sfUser implements ArrayAccess
   const ATTRIBUTE_NAMESPACE = 'symfony/user/sfUser/attributes';
 
   const CULTURE_NAMESPACE = 'symfony/user/sfUser/culture';
-
-  protected
-    $options         = array(),
-    $attributeHolder = null,
-    $culture         = null,
-    $storage         = null,
-    $dispatcher      = null;
-
+  
+  protected $options = array();
+  /** @var sfNamespacedParameterHolder */
+  protected $attributeHolder = null;
+  protected $culture = null;
+  /** @var sfStorage */
+  protected $storage = null;
+  /** @var sfEventDispatcher */
+  protected $dispatcher = null;
+  
   /**
    * Class constructor.
    *
    * @see initialize()
+   *
+   * @param sfEventDispatcher $dispatcher
+   * @param sfStorage         $storage
+   * @param array             $options
    */
   public function __construct(sfEventDispatcher $dispatcher, sfStorage $storage, $options = array())
   {
@@ -68,7 +74,7 @@ class sfUser implements ArrayAccess
    * @param sfStorage         $storage     An sfStorage instance.
    * @param array             $options     An associative array of options.
    *
-   * @return Boolean          true, if initialization completes successfully, otherwise false.
+   * @return void
    */
   public function initialize(sfEventDispatcher $dispatcher, sfStorage $storage, $options = array())
   {

--- a/lib/util/sfInflector.class.php
+++ b/lib/util/sfInflector.class.php
@@ -67,7 +67,7 @@ class sfInflector
    * @param string $class_name                Class name.
    * @param bool   $separate_with_underscore  Separate with underscore.
    *
-   * @return strong Foreign key
+   * @return string Foreign key
    */
   public static function foreign_key($class_name, $separate_with_underscore = true)
   {

--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -26,7 +26,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
 {
   protected $default_namespace = null;
   protected $parameters = array();
-
+  
   /**
    * The constructor for sfNamespacedParameterHolder.
    *
@@ -36,6 +36,8 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * $mySpecialPH = new sfNamespacedParameterHolder('symfony/special');
    * ?>
    * </code>
+   *
+   * @param string $namespace
    */
   public function __construct($namespace = 'symfony/default')
   {
@@ -150,7 +152,7 @@ class sfNamespacedParameterHolder extends sfParameterHolder
    * Retrieve an array of parameters, within a namespace.
    *
    * This method is limited to a namespace.  Without any argument,
-   * it returns the parameters of the default namespace.  If a 
+   * it returns the parameters of the default namespace.  If a
    * namespace is passed as an argument, only the parameters of the
    * specified namespace are returned.
    *
@@ -231,11 +233,13 @@ class sfNamespacedParameterHolder extends sfParameterHolder
 
     return $retval;
   }
-
+  
   /**
    * Remove A parameter namespace and all of its associated parameters.
    *
-   * @param string $ns  A parameter namespace.
+   * @param string $ns A parameter namespace.
+   *
+   * @return mixed|null
    */
   public function & removeNamespace($ns = null)
   {

--- a/lib/util/sfToolkit.class.php
+++ b/lib/util/sfToolkit.class.php
@@ -126,7 +126,7 @@ class sfToolkit
   /**
    * Determine if a filesystem path is absolute.
    *
-   * @param  path $path  A filesystem path.
+   * @param  string $path  A filesystem path.
    *
    * @return bool true, if the path is absolute, otherwise false.
    */

--- a/lib/widget/sfWidgetFormSchema.class.php
+++ b/lib/widget/sfWidgetFormSchema.class.php
@@ -611,6 +611,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
     // errors for hidden fields
     foreach ($this->positions as $name)
     {
+      /** @var $this sfWidgetForm[] */
       if ($this[$name] instanceof sfWidgetForm && $this[$name]->isHidden())
       {
         if (isset($errors[$name]))
@@ -723,7 +724,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
   /**
    * Returns an array of fields.
    *
-   * @return sfWidget An array of sfWidget instance
+   * @return sfWidget[] An array of sfWidget instance
    */
   public function getFields()
   {
@@ -789,7 +790,7 @@ class sfWidgetFormSchema extends sfWidgetForm implements ArrayAccess
    *  * sfWidgetFormSchema::FIRST
    *
    * @param string   $field  The field name to move
-   * @param constant $action The action (see above for all possible actions)
+   * @param string   $action The action (see above for all possible actions)
    * @param string   $pivot  The field name used for AFTER and BEFORE actions
    *
    * @throws InvalidArgumentException when field not exist

--- a/lib/widget/sfWidgetFormSchemaDecorator.class.php
+++ b/lib/widget/sfWidgetFormSchemaDecorator.class.php
@@ -41,22 +41,24 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
   /**
    * Returns the decorated widget.
    *
-   * @param sfWidget The decorated widget
+   * @return sfWidget The decorated widget
    */
   public function getWidget()
   {
     return $this->widget;
   }
-
+  
   /**
    * Renders the widget.
    *
-   * @param  string $name        The element name
-   * @param  string $values      The value displayed in this widget
-   * @param  array  $attributes  An array of HTML attributes to be merged with the default HTML attributes
-   * @param  array  $errors      An array of errors for the field
+   * @param  string $name       The element name
+   * @param  array  $values     The value displayed in this widget
+   * @param  array  $attributes An array of HTML attributes to be merged with the default HTML attributes
+   * @param  array  $errors     An array of errors for the field
    *
    * @see sfWidget
+   *
+   * @return string
    */
   public function render($name, $values = array(), $attributes = array(), $errors = array())
   {
@@ -65,6 +67,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function addFormFormatter($name, sfWidgetFormSchemaFormatter $formatter)
   {
@@ -83,6 +86,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setFormFormatterName($name)
   {
@@ -93,6 +97,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getFormFormatterName()
   {
@@ -101,6 +106,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getFormFormatter()
   {
@@ -109,6 +115,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setNameFormat($format)
   {
@@ -119,6 +126,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getNameFormat()
   {
@@ -127,6 +135,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setLabels(array $labels)
   {
@@ -137,6 +146,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getLabels()
   {
@@ -145,6 +155,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setLabel($name, $value = null)
   {
@@ -162,6 +173,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getLabel($name = null)
   {
@@ -170,6 +182,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setHelps(array $helps)
   {
@@ -180,6 +193,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getHelps()
   {
@@ -188,6 +202,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setHelp($name, $help)
   {
@@ -198,6 +213,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getHelp($name)
   {
@@ -234,6 +250,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function renderField($name, $value = null, $attributes = array(), $errors = array())
   {
@@ -242,6 +259,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchemaFormatter
+   * @inheritdoc
    */
   public function generateLabel($name)
   {
@@ -250,6 +268,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchemaFormatter
+   * @inheritdoc
    */
   public function generateLabelName($name)
   {
@@ -258,6 +277,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function generateName($name)
   {
@@ -266,6 +286,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getParent()
   {
@@ -274,6 +295,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setParent(sfWidgetFormSchema $parent = null)
   {
@@ -284,6 +306,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getFields()
   {
@@ -292,6 +315,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function getPositions()
   {
@@ -300,6 +324,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function setPositions(array $positions)
   {
@@ -310,6 +335,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function moveField($field, $action, $pivot = null)
   {
@@ -318,6 +344,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function offsetExists($name)
   {
@@ -326,6 +353,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function offsetGet($name)
   {
@@ -334,6 +362,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function offsetSet($name, $widget)
   {
@@ -342,6 +371,7 @@ class sfWidgetFormSchemaDecorator extends sfWidgetFormSchema
 
   /**
    * @see sfWidgetFormSchema
+   * @inheritdoc
    */
   public function offsetUnset($name)
   {


### PR DESCRIPTION
- No code changes
- Add return type hints comments
- Add class properties type hints comments
- Add method arguments type hints comments
- Fix inconsistency betwen doc comments and implementation
